### PR TITLE
fix: replace nodemailer SMTP with Brevo HTTP API for email delivery

### DIFF
--- a/backend/controller/userController.js
+++ b/backend/controller/userController.js
@@ -4,7 +4,7 @@ import ErrorHandler from '../middlewares/errorMiddleware.js';
 import { User } from '../models/userSchema.js';
 import { generateToken } from '../utils/jwtToken.js';
 import cloudinary from 'cloudinary';
-import transporter from '../utils/mailer.js';
+import { sendEmail } from '../utils/mailer.js';
 import { getOtpEmailHtml } from '../service/otpEmail.js';
 
 export const patientRegister = catchAsyncErrors(async (req, res, next) => {
@@ -29,7 +29,7 @@ export const patientRegister = catchAsyncErrors(async (req, res, next) => {
   const otp = Math.floor(100000 + Math.random() * 900000).toString();
   await redis.set(`otp:${email}`, otp, { ex: 300 });
 
-  await transporter.sendMail({
+  await sendEmail({
     to: email,
     subject: 'Your MedHaven Registration OTP',
     html: getOtpEmailHtml(otp, firstName),
@@ -106,7 +106,7 @@ export const resendOtp = catchAsyncErrors(async (req, res, next) => {
   const otp = Math.floor(100000 + Math.random() * 900000).toString();
   await redis.set(`otp:${email}`, otp, { ex: 300 });
 
-  await transporter.sendMail({
+  await sendEmail({
     to: email,
     subject: 'Your Registration OTP - Resend',
     html: getOtpEmailHtml(otp),

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "@getbrevo/brevo": "^5.0.4",
         "@upstash/ratelimit": "^2.0.6",
         "@upstash/redis": "^1.35.3",
         "bcrypt": "^5.1.1",
@@ -20,7 +21,6 @@
         "express-fileupload": "^1.5.1",
         "jsonwebtoken": "^9.0.2",
         "mongoose": "^8.6.0",
-        "nodemailer": "^7.0.5",
         "socket.io": "^4.8.1",
         "validator": "^13.12.0"
       },
@@ -29,6 +29,14 @@
       },
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@getbrevo/brevo": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@getbrevo/brevo/-/brevo-5.0.4.tgz",
+      "integrity": "sha512-wN4mHE6O0Pb/d/Dh3E4MAm2zCHbLLUcFF8/wgwTeMPy9KzHBYLu7S/nsJbzd0AWL09MHn8vwue8ULL9YOzluOQ==",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@mapbox/node-pre-gyp": {
@@ -124,6 +132,7 @@
       "resolved": "https://registry.npmjs.org/@upstash/redis/-/redis-1.35.3.tgz",
       "integrity": "sha512-hSjv66NOuahW3MisRGlSgoszU2uONAY2l5Qo3Sae8OT3/Tng9K+2/cBRuyPBX8egwEGcNNCF9+r0V6grNnhL+w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "uncrypto": "^0.1.3"
       }
@@ -1498,15 +1507,6 @@
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
-      }
-    },
-    "node_modules/nodemailer": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.5.tgz",
-      "integrity": "sha512-nsrh2lO3j4GkLLXoeEksAMgAOqxOv6QumNRVQTJwKH4nuiww6iC2y7GyANs9kRAxCexg3+lTWM3PZ91iLlVjfg==",
-      "license": "MIT-0",
-      "engines": {
-        "node": ">=6.0.0"
       }
     },
     "node_modules/nodemon": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -19,6 +19,7 @@
   },
   "homepage": "https://github.com/diveshsaini1991/Med-Haven#readme",
   "dependencies": {
+    "@getbrevo/brevo": "^5.0.4",
     "@upstash/ratelimit": "^2.0.6",
     "@upstash/redis": "^1.35.3",
     "bcrypt": "^5.1.1",
@@ -30,7 +31,6 @@
     "express-fileupload": "^1.5.1",
     "jsonwebtoken": "^9.0.2",
     "mongoose": "^8.6.0",
-    "nodemailer": "^7.0.5",
     "socket.io": "^4.8.1",
     "validator": "^13.12.0"
   },

--- a/backend/utils/mailer.js
+++ b/backend/utils/mailer.js
@@ -1,11 +1,19 @@
-import nodemailer from 'nodemailer';
+import SibApiV3Sdk from '@getbrevo/brevo';
 
-const transporter = nodemailer.createTransport({
-  service: 'gmail',
-  auth: {
-    user: process.env.EMAIL_USER,
-    pass: process.env.EMAIL_PASS,
-  },
-});
+const apiInstance = new SibApiV3Sdk.TransactionalEmailsApi();
+apiInstance.setApiKey(
+  SibApiV3Sdk.TransactionalEmailsApiApiKeys.apiKey,
+  process.env.BREVO_API_KEY
+);
 
-export default transporter;
+export const sendEmail = async ({ to, subject, html }) => {
+  const sendSmtpEmail = new SibApiV3Sdk.SendSmtpEmail();
+  sendSmtpEmail.sender = {
+    name: 'MedHaven',
+    email: process.env.SENDER_EMAIL,
+  };
+  sendSmtpEmail.to = [{ email: to }];
+  sendSmtpEmail.subject = subject;
+  sendSmtpEmail.htmlContent = html;
+  return apiInstance.sendTransacEmail(sendSmtpEmail);
+};


### PR DESCRIPTION
Render free tier blocks outbound SMTP ports (25, 465, 587), causing email sends to timeout. Brevo uses HTTPS (port 443) which is not blocked.

Env vars needed: BREVO_API_KEY, SENDER_EMAIL

fixes #45