### PR TITLE
feat: remove Aadhaar field from appointment booking form (#9)

### DIFF
--- a/frontend/src/components/AppointmentForm.jsx
+++ b/frontend/src/components/AppointmentForm.jsx
@@ -22,7 +22,6 @@ const defaultValues = {
   lastName: '',
   email: '',
   phone: '',
-  aadhaar: '',
   dob: '',
   gender: '',
   appointment_date: '',
@@ -194,16 +193,8 @@ const AppointmentForm = ({
               />
             </div>
 
-            {/* Aadhaar / Date of Birth */}
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-              <input
-                name="aadhaar"
-                type="number"
-                placeholder="Aadhaar"
-                value={form.aadhaar}
-                onChange={handleChange}
-                className="form-animate input-field"
-              />
+            {/* Date of Birth */}
+            <div className="grid grid-cols-1 gap-6">
               <DatePicker
                 selected={form.dob ? new Date(form.dob) : null}
                 onChange={(date) =>


### PR DESCRIPTION
## Summary
Removes the Aadhaar Number field from the appointment booking form. The backend no longer requires Aadhaar for booking (#8, already merged), so collecting it in the UI is unnecessary and avoids gathering sensitive PII.

## Changes
- Removed the `aadhaar` input from `frontend/src/components/AppointmentForm.jsx`.
- Removed `aadhaar` from the form's `defaultValues`.
- Date of Birth now occupies its own full-width row where the Aadhaar/DOB pair used to be.

## Notes
- Doctor/Admin registration forms still use Aadhaar (backend still requires it there) — out of scope.

Closes #9

## Test plan
- [ ] Open the booking form; confirm no Aadhaar field is shown.
- [ ] Submit an appointment; confirm it books successfully against the updated backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)