### PR TITLE
feat(backend): Forgot Password with OTP + reusable OTP service (#42)

### DIFF
--- a/backend/controller/userController.js
+++ b/backend/controller/userController.js
@@ -1,11 +1,13 @@
-import redis from '../config/redis.js';
 import { catchAsyncErrors } from '../middlewares/catchAsyncErrors.js';
 import ErrorHandler from '../middlewares/errorMiddleware.js';
 import { User } from '../models/userSchema.js';
 import { generateToken } from '../utils/jwtToken.js';
 import cloudinary from 'cloudinary';
-import { sendEmail } from '../utils/mailer.js';
-import { getOtpEmailHtml } from '../service/otpEmail.js';
+import {
+  sendOtp,
+  verifyOtp,
+  invalidateOtp,
+} from '../service/otpService.js';
 
 export const patientRegister = catchAsyncErrors(async (req, res, next) => {
   const { firstName, lastName, email, phone, password, gender, dob, role } =
@@ -26,13 +28,10 @@ export const patientRegister = catchAsyncErrors(async (req, res, next) => {
   if (user) {
     return next(new ErrorHandler('User Already Registered !', 400));
   }
-  const otp = Math.floor(100000 + Math.random() * 900000).toString();
-  await redis.set(`otp:${email}`, otp, { ex: 300 });
-
-  await sendEmail({
-    to: email,
+  await sendOtp({
+    email,
+    name: firstName,
     subject: 'Your MedHaven Registration OTP',
-    html: getOtpEmailHtml(otp, firstName),
   });
 
   res.status(200).json({
@@ -67,9 +66,8 @@ export const verifyPatientOtp = catchAsyncErrors(async (req, res, next) => {
   ) {
     return next(new ErrorHandler('All Fields Are Required!', 400));
   }
-  const savedOtp = await redis.get(`otp:${email}`);
-
-  if (!savedOtp || savedOtp != otp) {
+  const isOtpValid = await verifyOtp(email, otp);
+  if (!isOtpValid) {
     return next(new ErrorHandler('Invalid or expired OTP!', 400));
   }
   let user = await User.findOne({ email });
@@ -86,7 +84,7 @@ export const verifyPatientOtp = catchAsyncErrors(async (req, res, next) => {
     dob,
     role,
   });
-  await redis.del(`otp:${email}`);
+  await invalidateOtp(email);
   generateToken(user, 'User Registered!', 200, res);
 });
 
@@ -103,13 +101,9 @@ export const resendOtp = catchAsyncErrors(async (req, res, next) => {
     );
   }
 
-  const otp = Math.floor(100000 + Math.random() * 900000).toString();
-  await redis.set(`otp:${email}`, otp, { ex: 300 });
-
-  await sendEmail({
-    to: email,
+  await sendOtp({
+    email,
     subject: 'Your Registration OTP - Resend',
-    html: getOtpEmailHtml(otp),
   });
 
   res.status(200).json({
@@ -340,3 +334,66 @@ export const changePatientPassword = catchAsyncErrors(async (req, res, next) => 
     message: 'Password changed successfully.',
   });
 });
+
+export const forgotPatientPassword = catchAsyncErrors(
+  async (req, res, next) => {
+    const { email } = req.body;
+    if (!email) {
+      return next(new ErrorHandler('Email is required.', 400));
+    }
+
+    const user = await User.findOne({ email });
+    if (!user) {
+      return next(
+        new ErrorHandler('No account found with this email.', 404)
+      );
+    }
+
+    await sendOtp({
+      email,
+      name: user.firstName,
+      subject: 'Your MedHaven Password Reset OTP',
+    });
+
+    res.status(200).json({
+      success: true,
+      message: 'OTP sent to your email for password reset.',
+      email,
+    });
+  }
+);
+
+export const resetPatientPassword = catchAsyncErrors(
+  async (req, res, next) => {
+    const { email, otp, newPassword } = req.body;
+    if (!email || !otp || !newPassword) {
+      return next(
+        new ErrorHandler('Email, OTP and new password are required.', 400)
+      );
+    }
+    if (newPassword.length < 6) {
+      return next(
+        new ErrorHandler('Password Must Contain At Least 6 Characters!', 400)
+      );
+    }
+
+    const user = await User.findOne({ email }).select('+password');
+    if (!user) {
+      return next(new ErrorHandler('No account found with this email.', 404));
+    }
+
+    const isOtpValid = await verifyOtp(email, otp);
+    if (!isOtpValid) {
+      return next(new ErrorHandler('Invalid or expired OTP!', 400));
+    }
+
+    user.password = newPassword;
+    await user.save();
+    await invalidateOtp(email);
+
+    res.status(200).json({
+      success: true,
+      message: 'Password reset successfully. Please log in.',
+    });
+  }
+);

--- a/backend/router/userRouter.js
+++ b/backend/router/userRouter.js
@@ -3,6 +3,7 @@ import {
   addNewAdmin,
   addNewDoctor,
   changePatientPassword,
+  forgotPatientPassword,
   getAllDoctors,
   getUserDetails,
   login,
@@ -11,6 +12,7 @@ import {
   logoutPatient,
   patientRegister,
   resendOtp,
+  resetPatientPassword,
   verifyPatientOtp,
 } from '../controller/userController.js';
 import {
@@ -35,5 +37,7 @@ router.post('/doctor/addnew', isAdminAuthanticated, addNewDoctor);
 router.post('/patient/verify-otp', verifyPatientOtp);
 router.post('/patient/resend-otp', resendOtp);
 router.post('/patient/change-password', isPatientAuthanticated, changePatientPassword);
+router.post('/patient/forgot-password', forgotPatientPassword);
+router.post('/patient/reset-password', resetPatientPassword);
 
 export default router;

--- a/backend/service/otpService.js
+++ b/backend/service/otpService.js
@@ -1,0 +1,36 @@
+import redis from '../config/redis.js';
+import { sendEmail } from '../utils/mailer.js';
+import { getOtpEmailHtml } from './otpEmail.js';
+
+const OTP_EXPIRY_SECONDS = 300;
+
+const otpKey = (email) => `otp:${email}`;
+
+export const generateOtp = () =>
+  Math.floor(100000 + Math.random() * 900000).toString();
+
+export const storeOtp = async (email, otp) => {
+  await redis.set(otpKey(email), otp, { ex: OTP_EXPIRY_SECONDS });
+};
+
+// Generates an OTP, stores it in redis with expiry and emails it to the user.
+export const sendOtp = async ({ email, name = '', subject }) => {
+  const otp = generateOtp();
+  await storeOtp(email, otp);
+  await sendEmail({
+    to: email,
+    subject,
+    html: getOtpEmailHtml(otp, name),
+  });
+  return otp;
+};
+
+// Returns true when the supplied OTP matches the one stored for the email.
+export const verifyOtp = async (email, otp) => {
+  const savedOtp = await redis.get(otpKey(email));
+  return Boolean(savedOtp) && String(savedOtp) === String(otp);
+};
+
+export const invalidateOtp = async (email) => {
+  await redis.del(otpKey(email));
+};

--- a/backend/tests/integration/user.test.js
+++ b/backend/tests/integration/user.test.js
@@ -252,6 +252,119 @@ describe('User Routes', () => {
     });
   });
 
+  describe('POST /api/v1/user/patient/forgot-password', () => {
+    it('should send a reset OTP for a registered email', async () => {
+      redis.set.mockResolvedValue('OK');
+      await createTestUser({ email: 'forgot@test.com', role: 'Patient' });
+
+      const res = await request(app)
+        .post('/api/v1/user/patient/forgot-password')
+        .send({ email: 'forgot@test.com' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.email).toBe('forgot@test.com');
+    });
+
+    it('should fail for an unregistered email', async () => {
+      const res = await request(app)
+        .post('/api/v1/user/patient/forgot-password')
+        .send({ email: 'nobody@test.com' });
+
+      expect(res.status).toBe(404);
+      expect(res.body.success).toBe(false);
+    });
+
+    it('should fail when email is missing', async () => {
+      const res = await request(app)
+        .post('/api/v1/user/patient/forgot-password')
+        .send({});
+
+      expect(res.status).toBe(400);
+      expect(res.body.success).toBe(false);
+    });
+  });
+
+  describe('POST /api/v1/user/patient/reset-password', () => {
+    it('should reset password with a valid OTP', async () => {
+      redis.get.mockResolvedValue('123456');
+      redis.del.mockResolvedValue(1);
+      await createTestUser({
+        email: 'reset@test.com',
+        password: 'OldPass123',
+        role: 'Patient',
+      });
+
+      const res = await request(app)
+        .post('/api/v1/user/patient/reset-password')
+        .send({
+          email: 'reset@test.com',
+          otp: '123456',
+          newPassword: 'NewPass456',
+        });
+
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+
+      const login = await request(app)
+        .post('/api/v1/user/login')
+        .send({
+          email: 'reset@test.com',
+          password: 'NewPass456',
+          role: 'Patient',
+        });
+      expect(login.status).toBe(200);
+    });
+
+    it('should fail with an invalid OTP', async () => {
+      redis.get.mockResolvedValue('123456');
+      await createTestUser({ email: 'reset2@test.com', role: 'Patient' });
+
+      const res = await request(app)
+        .post('/api/v1/user/patient/reset-password')
+        .send({
+          email: 'reset2@test.com',
+          otp: '000000',
+          newPassword: 'NewPass456',
+        });
+
+      expect(res.status).toBe(400);
+      expect(res.body.success).toBe(false);
+      expect(res.body.message).toContain('OTP');
+    });
+
+    it('should fail with a weak new password', async () => {
+      redis.get.mockResolvedValue('123456');
+      await createTestUser({ email: 'reset3@test.com', role: 'Patient' });
+
+      const res = await request(app)
+        .post('/api/v1/user/patient/reset-password')
+        .send({
+          email: 'reset3@test.com',
+          otp: '123456',
+          newPassword: '123',
+        });
+
+      expect(res.status).toBe(400);
+      expect(res.body.success).toBe(false);
+    });
+
+    it('should fail for an unregistered email', async () => {
+      redis.get.mockResolvedValue('123456');
+
+      const res = await request(app)
+        .post('/api/v1/user/patient/reset-password')
+        .send({
+          email: 'ghost@test.com',
+          otp: '123456',
+          newPassword: 'NewPass456',
+        });
+
+      expect(res.status).toBe(404);
+      expect(res.body.success).toBe(false);
+    });
+  });
+
   describe('GET /api/v1/user/patient/logout', () => {
     it('should clear patient cookie', async () => {
       const patient = await createTestUser({ email: 'logout@test.com', role: 'Patient' });


### PR DESCRIPTION
## Summary
Backend support for the Forgot Password flow (child of #35), plus the OTP refactor the issue asked for. Builds on the already-merged change-password logic (#39/#44).

## Changes
**Reusable OTP service** — `backend/service/otpService.js`
- `generateOtp`, `storeOtp`, `sendOtp`, `verifyOtp`, `invalidateOtp` centralised in one module (single `otp:<email>` key namespace, 5-min expiry).
- `patientRegister`, `verifyPatientOtp`, `resendOtp` refactored to use it — behaviour and response messages unchanged.

**Forgot Password flow**
- `POST /api/v1/user/patient/forgot-password` → `{ email }`: validates the email belongs to a registered user, generates + stores an OTP, emails it.
- `POST /api/v1/user/patient/reset-password` → `{ email, otp, newPassword }`: verifies OTP, enforces min length (6, matches schema), sets the new (hashed) password, invalidates the OTP. **No authentication / old password required.**

**Error handling**: unregistered email (404), invalid/expired OTP (400), weak password (400), missing fields (400).

## Tests
- Added 7 integration tests (forgot-password: registered / unregistered / missing; reset-password: valid+login / invalid OTP / weak password / unregistered).
- Full suite: **95 passing**.
- ⚠️ Run tests on Node ≤ 24 (CI pins 18–24). Node 25 has an unrelated `jwa`/`buffer-equal-constant-time` incompatibility that breaks any jwt-importing suite.

Part of #35 · Closes #42

## Test plan
- [ ] `cd backend && npm test` (Node 20/22/24) → all green.
- [ ] Manual: forgot-password emails OTP; reset-password with that OTP lets the user log in with the new password.

🤖 Generated with [Claude Code](https://claude.com/claude-code)