### PR TITLE
feat(frontend): Forgot Password flow (#43)

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -21,6 +21,7 @@ import MyAppointments from './Pages/MyAppointments';
 import EditAppointment from './Pages/EditAppointment';
 import Chat from './Pages/Chat';
 import Profile from './Pages/Profile';
+import ForgotPassword from './Pages/ForgotPassword';
 
 const AppContent = () => {
   const { isAuthenticated, setIsAuthenticated, setUser } = useContext(Context);
@@ -58,6 +59,7 @@ const AppContent = () => {
         <Route path="/profile" element={<Profile />} />
         <Route path="/register" element={<Register />} />
         <Route path="/login" element={<Login />} />
+        <Route path="/forgot-password" element={<ForgotPassword />} />
       </Routes>
       {location.pathname !== '/chat' && <Footer />}
       <ToastContainer position="top-center" />

--- a/frontend/src/Pages/ForgotPassword.jsx
+++ b/frontend/src/Pages/ForgotPassword.jsx
@@ -1,0 +1,240 @@
+import axios from 'axios';
+import React, { useState, useRef, useEffect } from 'react';
+import { toast } from 'react-toastify';
+import { Link, useNavigate } from 'react-router-dom';
+import gsap from 'gsap';
+
+const ForgotPassword = () => {
+  const [email, setEmail] = useState('');
+  const [otp, setOtp] = useState('');
+  const [newPassword, setNewPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [step, setStep] = useState(1);
+  const [loading, setLoading] = useState(false);
+  const [resendCooldown, setResendCooldown] = useState(0);
+
+  const navigateTo = useNavigate();
+  const formRef = useRef(null);
+
+  useEffect(() => {
+    document.title = 'MedHaven - Forgot Password';
+  }, []);
+
+  useEffect(() => {
+    const ctx = gsap.context(() => {
+      gsap.from(gsap.utils.toArray('.forgot-animate'), {
+        opacity: 0,
+        y: 40,
+        duration: 0.8,
+        stagger: 0.12,
+        ease: 'power3.out',
+      });
+    }, formRef);
+    return () => ctx.revert();
+  }, [step]);
+
+  useEffect(() => {
+    if (resendCooldown === 0) return;
+    const timer = setInterval(() => {
+      setResendCooldown((prev) => {
+        if (prev <= 1) {
+          clearInterval(timer);
+          return 0;
+        }
+        return prev - 1;
+      });
+    }, 1000);
+    return () => clearInterval(timer);
+  }, [resendCooldown]);
+
+  const VITE_BACKEND_URL = import.meta.env.VITE_BACKEND_URL;
+
+  const requestOtp = async (e) => {
+    e?.preventDefault();
+    if (!email) {
+      toast.error('Please enter your registered email.');
+      return;
+    }
+    setLoading(true);
+    try {
+      const { data } = await axios.post(
+        `${VITE_BACKEND_URL}/api/v1/user/patient/forgot-password`,
+        { email },
+        { withCredentials: true, headers: { 'Content-Type': 'application/json' } }
+      );
+      toast.success(data.message);
+      setStep(2);
+      setResendCooldown(30);
+    } catch (error) {
+      toast.error(error.response?.data?.message || 'Failed to send OTP');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleResendOtp = async () => {
+    if (resendCooldown > 0) return;
+    await requestOtp();
+  };
+
+  const continueToReset = (e) => {
+    e.preventDefault();
+    if (!otp) {
+      toast.error('Please enter the OTP sent to your email.');
+      return;
+    }
+    setStep(3);
+  };
+
+  const resetPassword = async (e) => {
+    e.preventDefault();
+    if (!newPassword || !confirmPassword) {
+      toast.error('Please fill in both password fields.');
+      return;
+    }
+    if (newPassword.length < 6) {
+      toast.error('Password must be at least 6 characters.');
+      return;
+    }
+    if (newPassword !== confirmPassword) {
+      toast.error('Passwords do not match.');
+      return;
+    }
+    setLoading(true);
+    try {
+      const { data } = await axios.post(
+        `${VITE_BACKEND_URL}/api/v1/user/patient/reset-password`,
+        { email, otp, newPassword },
+        { withCredentials: true, headers: { 'Content-Type': 'application/json' } }
+      );
+      toast.success(data.message);
+      navigateTo('/login');
+    } catch (error) {
+      toast.error(error.response?.data?.message || 'Failed to reset password');
+      // Invalid/expired OTP — send the user back to the OTP step.
+      if (error.response?.data?.message?.toLowerCase().includes('otp')) {
+        setStep(2);
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <section className="min-h-screen flex items-center justify-center bg-gradient-to-b from-blue-50 to-white dark:from-gray-900 dark:to-gray-950 px-4">
+      <div
+        ref={formRef}
+        className="bg-white dark:bg-gray-900 rounded-2xl shadow-xl border border-gray-200 dark:border-gray-700 max-w-md w-full p-8"
+      >
+        <h2 className="forgot-animate text-3xl font-bold text-center text-blue-700 dark:text-blue-400 mb-4">
+          Forgot Password
+        </h2>
+
+        {step === 1 && (
+          <form onSubmit={requestOtp} className="space-y-5">
+            <p className="forgot-animate text-center text-gray-600 dark:text-gray-300 mb-2">
+              Enter your registered email and we'll send you a one-time
+              password to reset it.
+            </p>
+            <input
+              type="email"
+              placeholder="Registered Email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              className="forgot-animate w-full px-4 py-3 border-2 border-white text-gray-900 dark:text-white bg-white dark:bg-gray-800 rounded-lg shadow-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500 placeholder-gray-500 dark:placeholder-gray-300"
+            />
+            <button
+              type="submit"
+              disabled={loading}
+              className="forgot-animate w-full px-6 py-3 bg-blue-600 hover:bg-blue-700 text-white font-semibold rounded-full shadow-lg transform hover:scale-105 transition border-2 border-white disabled:opacity-50"
+            >
+              {loading ? 'Sending...' : 'Send OTP'}
+            </button>
+          </form>
+        )}
+
+        {step === 2 && (
+          <form onSubmit={continueToReset} className="space-y-5">
+            <p className="text-center text-gray-600 dark:text-gray-300 mb-2">
+              Enter the OTP sent to <strong>{email}</strong>
+            </p>
+            <input
+              type="text"
+              placeholder="Enter OTP"
+              value={otp}
+              onChange={(e) => setOtp(e.target.value)}
+              className="w-full px-4 py-3 text-gray-900 dark:text-white rounded-lg bg-white dark:bg-gray-800 border-2 border-white focus:ring-2 focus:ring-blue-500 outline-none transition placeholder-gray-500 dark:placeholder-gray-300"
+            />
+            <div className="flex justify-between gap-3">
+              <button
+                type="submit"
+                className="w-[48%] px-6 py-3 bg-blue-600 hover:bg-blue-700 text-white font-semibold rounded-full shadow-lg transform hover:scale-105 transition"
+              >
+                Continue
+              </button>
+              <button
+                type="button"
+                onClick={handleResendOtp}
+                disabled={resendCooldown > 0 || loading}
+                className={`w-[48%] px-6 py-3 rounded-full shadow-lg transform hover:scale-105 transition ${
+                  resendCooldown > 0
+                    ? 'bg-gray-400 cursor-not-allowed text-white'
+                    : 'border border-blue-600 text-blue-600 hover:bg-blue-50'
+                }`}
+              >
+                {resendCooldown > 0
+                  ? `Resend OTP in ${resendCooldown}s`
+                  : 'Resend OTP'}
+              </button>
+            </div>
+          </form>
+        )}
+
+        {step === 3 && (
+          <form onSubmit={resetPassword} className="space-y-5">
+            <p className="text-center text-gray-600 dark:text-gray-300 mb-2">
+              Set a new password for <strong>{email}</strong>
+            </p>
+            <input
+              type="password"
+              placeholder="New Password"
+              value={newPassword}
+              onChange={(e) => setNewPassword(e.target.value)}
+              autoComplete="new-password"
+              className="w-full px-4 py-3 text-gray-900 dark:text-white rounded-lg bg-white dark:bg-gray-800 border-2 border-white focus:ring-2 focus:ring-blue-500 outline-none transition placeholder-gray-500 dark:placeholder-gray-300"
+            />
+            <input
+              type="password"
+              placeholder="Confirm New Password"
+              value={confirmPassword}
+              onChange={(e) => setConfirmPassword(e.target.value)}
+              autoComplete="new-password"
+              className="w-full px-4 py-3 text-gray-900 dark:text-white rounded-lg bg-white dark:bg-gray-800 border-2 border-white focus:ring-2 focus:ring-blue-500 outline-none transition placeholder-gray-500 dark:placeholder-gray-300"
+            />
+            <button
+              type="submit"
+              disabled={loading}
+              className="w-full px-6 py-3 bg-blue-600 hover:bg-blue-700 text-white font-semibold rounded-full shadow-lg transform hover:scale-105 transition border-2 border-white disabled:opacity-50"
+            >
+              {loading ? 'Resetting...' : 'Reset Password'}
+            </button>
+          </form>
+        )}
+
+        <div className="flex items-center justify-center text-sm gap-2 mt-6">
+          <span className="text-gray-700 dark:text-gray-200">
+            Remembered your password?
+          </span>
+          <Link
+            to="/login"
+            className="text-blue-600 dark:text-blue-400 hover:underline"
+          >
+            Back to Login
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default ForgotPassword;

--- a/frontend/src/Pages/Login.jsx
+++ b/frontend/src/Pages/Login.jsx
@@ -99,6 +99,15 @@ const Login = () => {
             className="login-animate w-full px-4 py-3 border-2 border-white text-gray-900 dark:text-white bg-white dark:bg-gray-800 rounded-lg shadow-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500 placeholder-gray-500 dark:placeholder-gray-300"
           />
 
+          <div className="login-animate text-right text-sm">
+            <Link
+              to="/forgot-password"
+              className="text-blue-600 dark:text-blue-400 hover:underline"
+            >
+              Forgot Password?
+            </Link>
+          </div>
+
           <div className="login-animate flex items-center justify-center text-sm gap-2">
             <span className="text-gray-700 dark:text-gray-200">
               Not Registered?


### PR DESCRIPTION
## Summary
Frontend for the Forgot Password feature (child of #35). Consumes the endpoints added in #42 (`POST /forgot-password`, `POST /reset-password`).

## Changes
- **Login** (`Login.jsx`): added a **Forgot Password?** link → `/forgot-password`.
- **New page** `ForgotPassword.jsx` + route in `App.jsx`, 3-step flow styled to match Login/Register:
  1. **Email** → `POST /api/v1/user/patient/forgot-password` requests an OTP.
  2. **OTP** → reuses the registration OTP-entry pattern, with Resend (30s cooldown, via forgot-password since the user is already registered).
  3. **New password** → `POST /api/v1/user/patient/reset-password` with `{ email, otp, newPassword }`; confirm-match + min-length (6) validation. No old password required.
- Backend is the authoritative OTP check: an invalid/expired OTP error sends the user back to the OTP step. On success, redirect to `/login`.

## Dependency
Requires #42 (backend) to be merged for the endpoints to exist.

Part of #35 · Closes #43

## Test plan
- [ ] Login → Forgot Password? → submit registered email → receive OTP email.
- [ ] Enter OTP, set new password (mismatch/short rejected client-side).
- [ ] Wrong OTP → error + back to OTP step.
- [ ] Success → redirected to login, can sign in with the new password.

🤖 Generated with [Claude Code](https://claude.com/claude-code)