### PR TITLE
feat(backend): soft-delete own chat messages + socket broadcast (#26)

### DIFF
--- a/backend/config/chatSocket.js
+++ b/backend/config/chatSocket.js
@@ -31,6 +31,10 @@ export const setupChatSocket = (httpServer) => {
         .emit('notify', { text: 'New message!', ...message });
     });
 
+    socket.on('deleteMessage', ({ chatRoomId, messageId }) => {
+      socket.to(chatRoomId).emit('messageDeleted', { messageId });
+    });
+
     socket.on('typing', ({ chatRoomId, userId }) => {
       socket.to(chatRoomId).emit('showTyping', { userId });
     });

--- a/backend/controller/chatController.js
+++ b/backend/controller/chatController.js
@@ -54,6 +54,25 @@ export const editChat = catchAsyncErrors(async (req, res, next) => {
   res.json({ success: true, chat });
 });
 
+export const deleteChat = catchAsyncErrors(async (req, res, next) => {
+  const chat = await Chat.findById(req.params.id);
+  if (!chat)
+    return res.status(404).json({ success: false, message: 'Chat not found.' });
+
+  if (chat.senderId.toString() !== req.user._id.toString())
+    return res.status(403).json({ success: false, message: 'Not authorized.' });
+
+  chat.isDeleted = true;
+  chat.deletedAt = Date.now();
+  chat.text = '';
+  chat.imageUrls = [];
+  chat.fileUrls = [];
+
+  await chat.save();
+
+  res.json({ success: true, chatId: chat._id, chatRoomId: chat.chatRoomId });
+});
+
 export const getPatientList = catchAsyncErrors(async (req, res, next) => {
   const doctorId = req.user._id;
 

--- a/backend/models/chatSchema.js
+++ b/backend/models/chatSchema.js
@@ -30,6 +30,13 @@ const chatSchema = new mongoose.Schema({
     type: Boolean,
     default: false,
   },
+  isDeleted: {
+    type: Boolean,
+    default: false,
+  },
+  deletedAt: {
+    type: Date,
+  },
   sentAt: {
     type: Date,
     default: Date.now,

--- a/backend/router/chatRouter.js
+++ b/backend/router/chatRouter.js
@@ -3,6 +3,7 @@ import {
   createChatRoom,
   sendChat,
   editChat,
+  deleteChat,
   getChatRoomMessages,
   markChatRead,
   getUnreadChatsForUser,
@@ -16,6 +17,7 @@ const router = express.Router();
 router.post('/createRoom', isPatientOrDoctorAuthenticated, createChatRoom);
 router.post('/send', isPatientOrDoctorAuthenticated, sendChat);
 router.put('/edit/:id', isPatientOrDoctorAuthenticated, editChat);
+router.delete('/delete/:id', isPatientOrDoctorAuthenticated, deleteChat);
 router.get(
   '/room/:chatRoomId',
   isPatientOrDoctorAuthenticated,

--- a/backend/tests/integration/chat.test.js
+++ b/backend/tests/integration/chat.test.js
@@ -106,6 +106,59 @@ describe('Chat Routes', () => {
     });
   });
 
+  describe('DELETE /api/v1/chat/delete/:id', () => {
+    it('should allow sender to soft-delete their message', async () => {
+      const chat = await Chat.create({
+        chatRoomId,
+        senderId: patient._id,
+        receiverId: doctor._id,
+        text: 'Delete me',
+      });
+
+      const res = await request(app)
+        .delete(`/api/v1/chat/delete/${chat._id}`)
+        .set('Cookie', [patientCookie]);
+
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.chatId).toBe(chat._id.toString());
+
+      const updated = await Chat.findById(chat._id);
+      expect(updated.isDeleted).toBe(true);
+      expect(updated.text).toBe('');
+      expect(updated.deletedAt).toBeDefined();
+    });
+
+    it('should not allow non-sender to delete', async () => {
+      const chat = await Chat.create({
+        chatRoomId,
+        senderId: patient._id,
+        receiverId: doctor._id,
+        text: 'Patient message',
+      });
+
+      const res = await request(app)
+        .delete(`/api/v1/chat/delete/${chat._id}`)
+        .set('Cookie', [doctorCookie]);
+
+      expect(res.status).toBe(403);
+      expect(res.body.success).toBe(false);
+
+      const updated = await Chat.findById(chat._id);
+      expect(updated.isDeleted).toBe(false);
+    });
+
+    it('should return 404 for a non-existent message', async () => {
+      const fakeId = new mongoose.Types.ObjectId();
+      const res = await request(app)
+        .delete(`/api/v1/chat/delete/${fakeId}`)
+        .set('Cookie', [patientCookie]);
+
+      expect(res.status).toBe(404);
+      expect(res.body.success).toBe(false);
+    });
+  });
+
   describe('PUT /api/v1/chat/read/:id', () => {
     it('should mark chat as read', async () => {
       const chat = await Chat.create({


### PR DESCRIPTION
## Summary
Backend for letting users delete their own chat messages (child of #25), with real-time socket propagation.

## Changes
- **Schema** (`chatSchema.js`): added `isDeleted` (default false) and `deletedAt`.
- **Controller** (`deleteChat`): authorizes that the requester is the sender (403 otherwise, 404 if missing), then **soft-deletes** — sets `isDeleted`, stamps `deletedAt`, and clears `text`/`imageUrls`/`fileUrls` so content is no longer retrievable. Returns `{ chatId, chatRoomId }`.
- **Route**: `DELETE /api/v1/chat/delete/:id` (patient or doctor authenticated).
- **Socket** (`chatSocket.js`): added a `deleteMessage` relay that emits `messageDeleted` `{ messageId }` to the room, matching the existing client-relayed socket pattern (`sendChat` → `receiveChat`).

## Why soft delete
Keeps the message id/ordering stable for real-time clients while removing the content, per the issue's "no longer visible to any user".

## Tests
- Added 3 integration tests (sender delete, non-sender 403, 404). Chat suite: **11 passing**.
- ⚠️ Run on Node ≤ 24 (CI pins 18–24); Node 25 has an unrelated `jwa` incompatibility.

Part of #25 · Closes #26

## Test plan
- [ ] `cd backend && npm test` (Node 20/22/24) → green.
- [ ] Sender can delete; another user cannot; deleted message returns empty content with `isDeleted: true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)