### PR TITLE
feat(frontend): delete own chat messages with real-time updates (#27)

### DIFF
--- a/docDashboard/src/components/Chat.jsx
+++ b/docDashboard/src/components/Chat.jsx
@@ -11,6 +11,7 @@ import { io } from 'socket.io-client';
 import { Context } from '../main';
 import { toast } from 'react-toastify';
 import gsap from 'gsap';
+import { FaTrash } from 'react-icons/fa';
 
 const socket = io(import.meta.env.VITE_BACKEND_URL, {
   transports: ['websocket'],
@@ -108,6 +109,22 @@ const Chat = () => {
   }, [selectedPatient, admin]);
 
   useEffect(() => {
+    const onMessageDeleted = ({ messageId }) => {
+      setMessages((prev) =>
+        prev.map((m) =>
+          m._id === messageId
+            ? { ...m, isDeleted: true, text: '', imageUrls: [] }
+            : m
+        )
+      );
+    };
+    socket.on('messageDeleted', onMessageDeleted);
+    return () => {
+      socket.off('messageDeleted', onMessageDeleted);
+    };
+  }, []);
+
+  useEffect(() => {
     scrollToBottom();
   }, [messages]);
 
@@ -155,6 +172,29 @@ const Chat = () => {
     newMessageAddedRef.current = false;
     setMessages((prev) => [...prev, message]);
     setInput('');
+  };
+
+  const handleDeleteMessage = async (msg) => {
+    if (!msg?._id || !selectedPatient || !admin?._id) return;
+    if (!window.confirm('Delete this message? This cannot be undone.')) return;
+    const chatRoomId = generateChatRoomId(admin._id, selectedPatient.id);
+    try {
+      await axios.delete(
+        `${import.meta.env.VITE_BACKEND_URL}/api/v1/chat/delete/${msg._id}`,
+        { withCredentials: true }
+      );
+      socket.emit('deleteMessage', { chatRoomId, messageId: msg._id });
+      setMessages((prev) =>
+        prev.map((m) =>
+          m._id === msg._id
+            ? { ...m, isDeleted: true, text: '', imageUrls: [] }
+            : m
+        )
+      );
+      toast.success('Message deleted');
+    } catch {
+      toast.error('Failed to delete message');
+    }
   };
 
   return (
@@ -220,23 +260,39 @@ const Chat = () => {
                     No messages yet
                   </div>
                 )}
-                {messages.map((msg, idx) => (
-                  <div
-                    key={idx}
-                    className={`mb-2 flex ${msg.senderId === admin._id ? 'justify-end' : 'justify-start'}`}
-                    ref={idx === messages.length - 1 ? lastMessageRef : null}
-                  >
+                {messages.map((msg, idx) => {
+                  const isOwn = msg.senderId === admin._id;
+                  const canDelete = isOwn && msg._id && !msg.isDeleted;
+                  return (
                     <div
-                      className={`px-4 py-2 rounded-lg max-w-xs ${
-                        msg.senderId === admin._id
-                          ? 'bg-blue-600 text-white'
-                          : 'bg-gray-300 dark:bg-gray-700 text-black dark:text-white'
-                      }`}
+                      key={msg._id || idx}
+                      className={`mb-2 flex items-center gap-2 group ${isOwn ? 'justify-end' : 'justify-start'}`}
+                      ref={idx === messages.length - 1 ? lastMessageRef : null}
                     >
-                      {msg.text}
+                      {canDelete && (
+                        <button
+                          onClick={() => handleDeleteMessage(msg)}
+                          title="Delete message"
+                          aria-label="Delete message"
+                          className="opacity-0 group-hover:opacity-100 transition text-gray-400 hover:text-red-500 cursor-pointer"
+                        >
+                          <FaTrash size={14} />
+                        </button>
+                      )}
+                      <div
+                        className={`px-4 py-2 rounded-lg max-w-xs ${
+                          msg.isDeleted
+                            ? 'bg-gray-200 dark:bg-gray-800 text-gray-500 italic'
+                            : isOwn
+                              ? 'bg-blue-600 text-white'
+                              : 'bg-gray-300 dark:bg-gray-700 text-black dark:text-white'
+                        }`}
+                      >
+                        {msg.isDeleted ? 'This message was deleted' : msg.text}
+                      </div>
                     </div>
-                  </div>
-                ))}
+                  );
+                })}
                 <div ref={messagesEndRef} />
               </div>
               <div className="flex pb-2">

--- a/frontend/src/Pages/Chat.jsx
+++ b/frontend/src/Pages/Chat.jsx
@@ -119,6 +119,22 @@ const Chat = () => {
     };
   }, [selectedChat, user]);
 
+  useEffect(() => {
+    const onMessageDeleted = ({ messageId }) => {
+      setMessages((prev) =>
+        prev.map((m) =>
+          m._id === messageId
+            ? { ...m, isDeleted: true, text: '', imageUrls: [] }
+            : m
+        )
+      );
+    };
+    socket.on('messageDeleted', onMessageDeleted);
+    return () => {
+      socket.off('messageDeleted', onMessageDeleted);
+    };
+  }, []);
+
   const handleImageUpload = async (file) => {
     if (!file) return;
     toast.info('Uploading image...');
@@ -212,6 +228,28 @@ const Chat = () => {
     setUploadedImageUrls([]);
   };
 
+  const handleDeleteMessage = async (msg) => {
+    if (!msg?._id || !selectedChat || !user?._id) return;
+    const chatRoomId = generateChatRoomId(user._id, selectedChat.id);
+    try {
+      await axios.delete(
+        `${import.meta.env.VITE_BACKEND_URL}/api/v1/chat/delete/${msg._id}`,
+        { withCredentials: true }
+      );
+      socket.emit('deleteMessage', { chatRoomId, messageId: msg._id });
+      setMessages((prev) =>
+        prev.map((m) =>
+          m._id === msg._id
+            ? { ...m, isDeleted: true, text: '', imageUrls: [] }
+            : m
+        )
+      );
+      toast.success('Message deleted');
+    } catch {
+      toast.error('Failed to delete message');
+    }
+  };
+
   const toggleDepartment = (dept) => {
     setDepartmentsOpen((prev) => ({
       ...prev,
@@ -294,6 +332,7 @@ const Chat = () => {
                 uploadedImageUrls={uploadedImageUrls}
                 setUploadedImageUrls={setUploadedImageUrls}
                 handleMultipleImageUpload={handleMultipleImageUpload}
+                handleDeleteMessage={handleDeleteMessage}
               />
             </div>
           )}

--- a/frontend/src/components/ChatRoom.jsx
+++ b/frontend/src/components/ChatRoom.jsx
@@ -1,6 +1,7 @@
 import gsap from 'gsap';
 import React, { useLayoutEffect, useRef, useState } from 'react';
 import { HiOutlinePhotograph } from 'react-icons/hi';
+import { FaTrash } from 'react-icons/fa';
 import { getLowResCloudinaryUrl } from '../utils/cloudinaryHelpers';
 
 const ChatRoom = ({
@@ -20,7 +21,14 @@ const ChatRoom = ({
   uploadedImageUrls,
   setUploadedImageUrls,
   handleMultipleImageUpload,
+  handleDeleteMessage,
 }) => {
+  const onDeleteClick = (msg) => {
+    if (window.confirm('Delete this message? This cannot be undone.')) {
+      handleDeleteMessage(msg);
+    }
+  };
+
   const [showImageOverlay, setShowImageOverlay] = useState(false);
   const [overlayImageUrl, setOverlayImageUrl] = useState(null);
   const overlayRef = useRef(null);
@@ -135,35 +143,57 @@ const ChatRoom = ({
                 No messages yet
               </div>
             )}
-            {messages.map((msg, idx) => (
-              <div
-                key={idx}
-                className={`mb-2 flex ${
-                  msg.senderId === user._id ? 'justify-end' : 'justify-start'
-                }`}
-                ref={idx === messages.length - 1 ? lastMessageRef : null}
-              >
+            {messages.map((msg, idx) => {
+              const isOwn = msg.senderId === user._id;
+              const canDelete = isOwn && msg._id && !msg.isDeleted;
+              return (
                 <div
-                  className={`px-4 py-2 rounded-lg max-w-xs ${
-                    msg.senderId === user._id
-                      ? 'bg-blue-600 text-white'
-                      : 'bg-gray-300 dark:bg-gray-700 text-black dark:text-white'
+                  key={msg._id || idx}
+                  className={`mb-2 flex items-center gap-2 group ${
+                    isOwn ? 'justify-end' : 'justify-start'
                   }`}
+                  ref={idx === messages.length - 1 ? lastMessageRef : null}
                 >
-                  <div>{msg.text}</div>
-                  {msg.imageUrls &&
-                    msg.imageUrls.map((url, i) => (
-                      <img
-                        key={i}
-                        src={getLowResCloudinaryUrl(url, 400, 200)}
-                        alt={`chat-img-${i}`}
-                        className="mt-2 w-40 h-40 object-cover rounded cursor-pointer"
-                        onClick={() => openImageOverlay(url)}
-                      />
-                    ))}
+                  {canDelete && (
+                    <button
+                      onClick={() => onDeleteClick(msg)}
+                      title="Delete message"
+                      aria-label="Delete message"
+                      className="opacity-0 group-hover:opacity-100 transition text-gray-400 hover:text-red-500 cursor-pointer"
+                    >
+                      <FaTrash size={14} />
+                    </button>
+                  )}
+                  <div
+                    className={`px-4 py-2 rounded-lg max-w-xs ${
+                      msg.isDeleted
+                        ? 'bg-gray-200 dark:bg-gray-800 text-gray-500 italic'
+                        : isOwn
+                          ? 'bg-blue-600 text-white'
+                          : 'bg-gray-300 dark:bg-gray-700 text-black dark:text-white'
+                    }`}
+                  >
+                    {msg.isDeleted ? (
+                      <div>This message was deleted</div>
+                    ) : (
+                      <>
+                        <div>{msg.text}</div>
+                        {msg.imageUrls &&
+                          msg.imageUrls.map((url, i) => (
+                            <img
+                              key={i}
+                              src={getLowResCloudinaryUrl(url, 400, 200)}
+                              alt={`chat-img-${i}`}
+                              className="mt-2 w-40 h-40 object-cover rounded cursor-pointer"
+                              onClick={() => openImageOverlay(url)}
+                            />
+                          ))}
+                      </>
+                    )}
+                  </div>
                 </div>
-              </div>
-            ))}
+              );
+            })}
             <div ref={messagesEndRef} />
           </div>
 


### PR DESCRIPTION
## Summary
Frontend for deleting your own chat messages (child of #25), in both the patient and doctor chat UIs. Consumes the backend from #26.

## Changes
**Patient app** — `frontend/src/Pages/Chat.jsx` + `components/ChatRoom.jsx`
- `handleDeleteMessage`: `DELETE /api/v1/chat/delete/:id`, emit `deleteMessage` `{ chatRoomId, messageId }`, update local state.
- Listen for `messageDeleted` to update the chat view in real time.
- Trash icon (hover) on own persisted, non-deleted messages → `window.confirm` before deleting.
- Deleted messages render an italic "This message was deleted" placeholder.

**Doctor app** — `docDashboard/src/components/Chat.jsx`
- Same delete handler, socket listener, control and placeholder for the doctor's own messages.

## Notes
- Delete control only shows for messages with a server `_id` (an optimistic just-sent message gets its id on the next room fetch).

## Dependency
Requires #26 (backend) merged.

Part of #25 · Closes #27

## Test plan
- [ ] Patient deletes own message → disappears (placeholder) for patient and doctor live.
- [ ] Doctor deletes own message → same, both sides.
- [ ] No delete control on the other party's messages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)