### PR TITLE
feat(backend): broadcast chat message edits over socket (#29)

### DIFF
--- a/backend/config/chatSocket.js
+++ b/backend/config/chatSocket.js
@@ -31,6 +31,10 @@ export const setupChatSocket = (httpServer) => {
         .emit('notify', { text: 'New message!', ...message });
     });
 
+    socket.on('editMessage', ({ chatRoomId, messageId, text }) => {
+      socket.to(chatRoomId).emit('messageEdited', { messageId, text });
+    });
+
     socket.on('typing', ({ chatRoomId, userId }) => {
       socket.to(chatRoomId).emit('showTyping', { userId });
     });

--- a/backend/tests/integration/chat.test.js
+++ b/backend/tests/integration/chat.test.js
@@ -104,6 +104,17 @@ describe('Chat Routes', () => {
       expect(res.status).toBe(403);
       expect(res.body.success).toBe(false);
     });
+
+    it('should return 404 when editing a non-existent message', async () => {
+      const fakeId = new mongoose.Types.ObjectId();
+      const res = await request(app)
+        .put(`/api/v1/chat/edit/${fakeId}`)
+        .set('Cookie', [patientCookie])
+        .send({ text: 'No such message' });
+
+      expect(res.status).toBe(404);
+      expect(res.body.success).toBe(false);
+    });
   });
 
   describe('PUT /api/v1/chat/read/:id', () => {


### PR DESCRIPTION
## Summary
Completes backend support for editing own chat messages (child of #28) by adding the real-time socket broadcast.

## Context
`PUT /api/v1/chat/edit/:id` already exists: it authorizes the sender (403 otherwise, 404 if missing), updates the content and sets `isEdited`. The only missing piece from the issue was socket integration.

## Changes
- **Socket** (`chatSocket.js`): added an `editMessage` relay that emits `messageEdited` `{ messageId, text }` to the chat room, mirroring the existing `sendChat` → `receiveChat` pattern.
- **Test**: added a 404 case for editing a non-existent message (permission-violation 403 is already covered).

## Tests
- Chat suite: **9 passing**.
- ⚠️ Run on Node ≤ 24 (CI pins 18–24); Node 25 has an unrelated `jwa` incompatibility.

Part of #28 · Closes #29

## Test plan
- [ ] `cd backend && npm test` (Node 20/22/24) → green.
- [ ] Editing as sender updates content + `isEdited`; non-sender 403; missing 404; other room clients receive `messageEdited`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)