### PR TITLE
feat(frontend): edit own chat messages with real-time updates (#30)

### DIFF
--- a/docDashboard/src/components/Chat.jsx
+++ b/docDashboard/src/components/Chat.jsx
@@ -25,6 +25,8 @@ const Chat = () => {
   const [messages, setMessages] = useState([]);
   const [input, setInput] = useState('');
   const [sendingDisabled, setSendingDisabled] = useState(false);
+  const [editingId, setEditingId] = useState(null);
+  const [editText, setEditText] = useState('');
   const navigate = useNavigate();
   const messagesEndRef = useRef(null);
   const lastMessageRef = useRef(null);
@@ -125,6 +127,20 @@ const Chat = () => {
   }, []);
 
   useEffect(() => {
+    const onMessageEdited = ({ messageId, text }) => {
+      setMessages((prev) =>
+        prev.map((m) =>
+          m._id === messageId ? { ...m, text, isEdited: true } : m
+        )
+      );
+    };
+    socket.on('messageEdited', onMessageEdited);
+    return () => {
+      socket.off('messageEdited', onMessageEdited);
+    };
+  }, []);
+
+  useEffect(() => {
     scrollToBottom();
   }, [messages]);
 
@@ -197,6 +213,42 @@ const Chat = () => {
     }
   };
 
+  const startEditing = (msg) => {
+    setEditingId(msg._id);
+    setEditText(msg.text || '');
+  };
+
+  const cancelEditing = () => {
+    setEditingId(null);
+    setEditText('');
+  };
+
+  const saveEditing = async (msg) => {
+    const trimmed = editText.trim();
+    if (!trimmed || trimmed === msg.text || !selectedPatient || !admin?._id) {
+      cancelEditing();
+      return;
+    }
+    const chatRoomId = generateChatRoomId(admin._id, selectedPatient.id);
+    try {
+      await axios.put(
+        `${import.meta.env.VITE_BACKEND_URL}/api/v1/chat/edit/${msg._id}`,
+        { text: trimmed },
+        { withCredentials: true }
+      );
+      socket.emit('editMessage', { chatRoomId, messageId: msg._id, text: trimmed });
+      setMessages((prev) =>
+        prev.map((m) =>
+          m._id === msg._id ? { ...m, text: trimmed, isEdited: true } : m
+        )
+      );
+      toast.success('Message edited');
+    } catch {
+      toast.error('Failed to edit message');
+    }
+    cancelEditing();
+  };
+
   return (
     <div
       className="fixed inset-0 bg-gray-900 flex flex-col overflow-hidden text-white"
@@ -262,22 +314,33 @@ const Chat = () => {
                 )}
                 {messages.map((msg, idx) => {
                   const isOwn = msg.senderId === admin._id;
-                  const canDelete = isOwn && msg._id && !msg.isDeleted;
+                  const canModify = isOwn && msg._id && !msg.isDeleted;
+                  const isEditing = editingId === msg._id;
                   return (
                     <div
                       key={msg._id || idx}
                       className={`mb-2 flex items-center gap-2 group ${isOwn ? 'justify-end' : 'justify-start'}`}
                       ref={idx === messages.length - 1 ? lastMessageRef : null}
                     >
-                      {canDelete && (
-                        <button
-                          onClick={() => handleDeleteMessage(msg)}
-                          title="Delete message"
-                          aria-label="Delete message"
-                          className="opacity-0 group-hover:opacity-100 transition text-gray-400 hover:text-red-500 cursor-pointer"
-                        >
-                          <FaTrash size={14} />
-                        </button>
+                      {canModify && !isEditing && (
+                        <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition">
+                          <button
+                            onClick={() => startEditing(msg)}
+                            title="Edit message"
+                            aria-label="Edit message"
+                            className="text-gray-400 hover:text-blue-500 cursor-pointer"
+                          >
+                            <FaPencilAlt size={13} />
+                          </button>
+                          <button
+                            onClick={() => handleDeleteMessage(msg)}
+                            title="Delete message"
+                            aria-label="Delete message"
+                            className="text-gray-400 hover:text-red-500 cursor-pointer"
+                          >
+                            <FaTrash size={13} />
+                          </button>
+                        </div>
                       )}
                       <div
                         className={`px-4 py-2 rounded-lg max-w-xs ${
@@ -288,7 +351,46 @@ const Chat = () => {
                               : 'bg-gray-300 dark:bg-gray-700 text-black dark:text-white'
                         }`}
                       >
-                        {msg.isDeleted ? 'This message was deleted' : msg.text}
+                        {msg.isDeleted ? (
+                          'This message was deleted'
+                        ) : isEditing ? (
+                          <div className="flex flex-col gap-2">
+                            <input
+                              type="text"
+                              value={editText}
+                              onChange={(e) => setEditText(e.target.value)}
+                              onKeyDown={(e) => {
+                                if (e.key === 'Enter') saveEditing(msg);
+                                if (e.key === 'Escape') cancelEditing();
+                              }}
+                              autoFocus
+                              className="px-2 py-1 rounded text-black dark:text-white bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 focus:outline-none"
+                            />
+                            <div className="flex gap-2 justify-end text-xs">
+                              <button
+                                onClick={() => saveEditing(msg)}
+                                className="px-2 py-1 rounded bg-white/20 hover:bg-white/30"
+                              >
+                                Save
+                              </button>
+                              <button
+                                onClick={cancelEditing}
+                                className="px-2 py-1 rounded bg-white/20 hover:bg-white/30"
+                              >
+                                Cancel
+                              </button>
+                            </div>
+                          </div>
+                        ) : (
+                          <>
+                            {msg.text}
+                            {msg.isEdited && (
+                              <span className="block text-[10px] opacity-70 mt-1">
+                                (edited)
+                              </span>
+                            )}
+                          </>
+                        )}
                       </div>
                     </div>
                   );

--- a/docDashboard/src/components/Chat.jsx
+++ b/docDashboard/src/components/Chat.jsx
@@ -11,6 +11,7 @@ import { io } from 'socket.io-client';
 import { Context } from '../main';
 import { toast } from 'react-toastify';
 import gsap from 'gsap';
+import { FaTrash } from 'react-icons/fa';
 
 const socket = io(import.meta.env.VITE_BACKEND_URL, {
   transports: ['websocket'],
@@ -108,6 +109,22 @@ const Chat = () => {
   }, [selectedPatient, admin]);
 
   useEffect(() => {
+    const onMessageDeleted = ({ messageId }) => {
+      setMessages((prev) =>
+        prev.map((m) =>
+          m._id === messageId
+            ? { ...m, isDeleted: true, text: '', imageUrls: [] }
+            : m
+        )
+      );
+    };
+    socket.on('messageDeleted', onMessageDeleted);
+    return () => {
+      socket.off('messageDeleted', onMessageDeleted);
+    };
+  }, []);
+
+  useEffect(() => {
     scrollToBottom();
   }, [messages]);
 
@@ -155,6 +172,29 @@ const Chat = () => {
     newMessageAddedRef.current = false;
     setMessages((prev) => [...prev, message]);
     setInput('');
+  };
+
+  const handleDeleteMessage = async (msg) => {
+    if (!msg?._id || !selectedPatient || !admin?._id) return;
+    if (!window.confirm('Delete this message? This cannot be undone.')) return;
+    const chatRoomId = generateChatRoomId(admin._id, selectedPatient.id);
+    try {
+      await axios.delete(
+        `${import.meta.env.VITE_BACKEND_URL}/api/v1/chat/delete/${msg._id}`,
+        { withCredentials: true }
+      );
+      socket.emit('deleteMessage', { chatRoomId, messageId: msg._id });
+      setMessages((prev) =>
+        prev.map((m) =>
+          m._id === msg._id
+            ? { ...m, isDeleted: true, text: '', imageUrls: [] }
+            : m
+        )
+      );
+      toast.success('Message deleted');
+    } catch {
+      toast.error('Failed to delete message');
+    }
   };
 
   return (
@@ -220,23 +260,39 @@ const Chat = () => {
                     No messages yet
                   </div>
                 )}
-                {messages.map((msg, idx) => (
-                  <div
-                    key={idx}
-                    className={`mb-2 flex ${msg.senderId === admin._id ? 'justify-end' : 'justify-start'}`}
-                    ref={idx === messages.length - 1 ? lastMessageRef : null}
-                  >
+                {messages.map((msg, idx) => {
+                  const isOwn = msg.senderId === admin._id;
+                  const canDelete = isOwn && msg._id && !msg.isDeleted;
+                  return (
                     <div
-                      className={`px-4 py-2 rounded-lg max-w-xs ${
-                        msg.senderId === admin._id
-                          ? 'bg-blue-600 text-white'
-                          : 'bg-gray-300 dark:bg-gray-700 text-black dark:text-white'
-                      }`}
+                      key={msg._id || idx}
+                      className={`mb-2 flex items-center gap-2 group ${isOwn ? 'justify-end' : 'justify-start'}`}
+                      ref={idx === messages.length - 1 ? lastMessageRef : null}
                     >
-                      {msg.text}
+                      {canDelete && (
+                        <button
+                          onClick={() => handleDeleteMessage(msg)}
+                          title="Delete message"
+                          aria-label="Delete message"
+                          className="opacity-0 group-hover:opacity-100 transition text-gray-400 hover:text-red-500 cursor-pointer"
+                        >
+                          <FaTrash size={14} />
+                        </button>
+                      )}
+                      <div
+                        className={`px-4 py-2 rounded-lg max-w-xs ${
+                          msg.isDeleted
+                            ? 'bg-gray-200 dark:bg-gray-800 text-gray-500 italic'
+                            : isOwn
+                              ? 'bg-blue-600 text-white'
+                              : 'bg-gray-300 dark:bg-gray-700 text-black dark:text-white'
+                        }`}
+                      >
+                        {msg.isDeleted ? 'This message was deleted' : msg.text}
+                      </div>
                     </div>
-                  </div>
-                ))}
+                  );
+                })}
                 <div ref={messagesEndRef} />
               </div>
               <div className="flex pb-2">

--- a/frontend/src/Pages/Chat.jsx
+++ b/frontend/src/Pages/Chat.jsx
@@ -119,6 +119,22 @@ const Chat = () => {
     };
   }, [selectedChat, user]);
 
+  useEffect(() => {
+    const onMessageDeleted = ({ messageId }) => {
+      setMessages((prev) =>
+        prev.map((m) =>
+          m._id === messageId
+            ? { ...m, isDeleted: true, text: '', imageUrls: [] }
+            : m
+        )
+      );
+    };
+    socket.on('messageDeleted', onMessageDeleted);
+    return () => {
+      socket.off('messageDeleted', onMessageDeleted);
+    };
+  }, []);
+
   const handleImageUpload = async (file) => {
     if (!file) return;
     toast.info('Uploading image...');
@@ -212,6 +228,28 @@ const Chat = () => {
     setUploadedImageUrls([]);
   };
 
+  const handleDeleteMessage = async (msg) => {
+    if (!msg?._id || !selectedChat || !user?._id) return;
+    const chatRoomId = generateChatRoomId(user._id, selectedChat.id);
+    try {
+      await axios.delete(
+        `${import.meta.env.VITE_BACKEND_URL}/api/v1/chat/delete/${msg._id}`,
+        { withCredentials: true }
+      );
+      socket.emit('deleteMessage', { chatRoomId, messageId: msg._id });
+      setMessages((prev) =>
+        prev.map((m) =>
+          m._id === msg._id
+            ? { ...m, isDeleted: true, text: '', imageUrls: [] }
+            : m
+        )
+      );
+      toast.success('Message deleted');
+    } catch {
+      toast.error('Failed to delete message');
+    }
+  };
+
   const toggleDepartment = (dept) => {
     setDepartmentsOpen((prev) => ({
       ...prev,
@@ -294,6 +332,7 @@ const Chat = () => {
                 uploadedImageUrls={uploadedImageUrls}
                 setUploadedImageUrls={setUploadedImageUrls}
                 handleMultipleImageUpload={handleMultipleImageUpload}
+                handleDeleteMessage={handleDeleteMessage}
               />
             </div>
           )}

--- a/frontend/src/Pages/Chat.jsx
+++ b/frontend/src/Pages/Chat.jsx
@@ -135,6 +135,20 @@ const Chat = () => {
     };
   }, []);
 
+  useEffect(() => {
+    const onMessageEdited = ({ messageId, text }) => {
+      setMessages((prev) =>
+        prev.map((m) =>
+          m._id === messageId ? { ...m, text, isEdited: true } : m
+        )
+      );
+    };
+    socket.on('messageEdited', onMessageEdited);
+    return () => {
+      socket.off('messageEdited', onMessageEdited);
+    };
+  }, []);
+
   const handleImageUpload = async (file) => {
     if (!file) return;
     toast.info('Uploading image...');
@@ -250,6 +264,28 @@ const Chat = () => {
     }
   };
 
+  const handleEditMessage = async (msg, newText) => {
+    const trimmed = (newText || '').trim();
+    if (!msg?._id || !selectedChat || !user?._id || !trimmed) return;
+    const chatRoomId = generateChatRoomId(user._id, selectedChat.id);
+    try {
+      await axios.put(
+        `${import.meta.env.VITE_BACKEND_URL}/api/v1/chat/edit/${msg._id}`,
+        { text: trimmed },
+        { withCredentials: true }
+      );
+      socket.emit('editMessage', { chatRoomId, messageId: msg._id, text: trimmed });
+      setMessages((prev) =>
+        prev.map((m) =>
+          m._id === msg._id ? { ...m, text: trimmed, isEdited: true } : m
+        )
+      );
+      toast.success('Message edited');
+    } catch {
+      toast.error('Failed to edit message');
+    }
+  };
+
   const toggleDepartment = (dept) => {
     setDepartmentsOpen((prev) => ({
       ...prev,
@@ -333,6 +369,7 @@ const Chat = () => {
                 setUploadedImageUrls={setUploadedImageUrls}
                 handleMultipleImageUpload={handleMultipleImageUpload}
                 handleDeleteMessage={handleDeleteMessage}
+                handleEditMessage={handleEditMessage}
               />
             </div>
           )}

--- a/frontend/src/components/ChatRoom.jsx
+++ b/frontend/src/components/ChatRoom.jsx
@@ -1,7 +1,7 @@
 import gsap from 'gsap';
 import React, { useLayoutEffect, useRef, useState } from 'react';
 import { HiOutlinePhotograph } from 'react-icons/hi';
-import { FaTrash } from 'react-icons/fa';
+import { FaTrash, FaPencilAlt } from 'react-icons/fa';
 import { getLowResCloudinaryUrl } from '../utils/cloudinaryHelpers';
 
 const ChatRoom = ({
@@ -22,11 +22,35 @@ const ChatRoom = ({
   setUploadedImageUrls,
   handleMultipleImageUpload,
   handleDeleteMessage,
+  handleEditMessage,
 }) => {
+  const [editingId, setEditingId] = useState(null);
+  const [editText, setEditText] = useState('');
+
   const onDeleteClick = (msg) => {
     if (window.confirm('Delete this message? This cannot be undone.')) {
       handleDeleteMessage(msg);
     }
+  };
+
+  const startEditing = (msg) => {
+    setEditingId(msg._id);
+    setEditText(msg.text || '');
+  };
+
+  const cancelEditing = () => {
+    setEditingId(null);
+    setEditText('');
+  };
+
+  const saveEditing = async (msg) => {
+    const trimmed = editText.trim();
+    if (!trimmed || trimmed === msg.text) {
+      cancelEditing();
+      return;
+    }
+    await handleEditMessage(msg, trimmed);
+    cancelEditing();
   };
 
   const [showImageOverlay, setShowImageOverlay] = useState(false);
@@ -145,7 +169,8 @@ const ChatRoom = ({
             )}
             {messages.map((msg, idx) => {
               const isOwn = msg.senderId === user._id;
-              const canDelete = isOwn && msg._id && !msg.isDeleted;
+              const canModify = isOwn && msg._id && !msg.isDeleted;
+              const isEditing = editingId === msg._id;
               return (
                 <div
                   key={msg._id || idx}
@@ -154,15 +179,25 @@ const ChatRoom = ({
                   }`}
                   ref={idx === messages.length - 1 ? lastMessageRef : null}
                 >
-                  {canDelete && (
-                    <button
-                      onClick={() => onDeleteClick(msg)}
-                      title="Delete message"
-                      aria-label="Delete message"
-                      className="opacity-0 group-hover:opacity-100 transition text-gray-400 hover:text-red-500 cursor-pointer"
-                    >
-                      <FaTrash size={14} />
-                    </button>
+                  {canModify && !isEditing && (
+                    <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition">
+                      <button
+                        onClick={() => startEditing(msg)}
+                        title="Edit message"
+                        aria-label="Edit message"
+                        className="text-gray-400 hover:text-blue-500 cursor-pointer"
+                      >
+                        <FaPencilAlt size={13} />
+                      </button>
+                      <button
+                        onClick={() => onDeleteClick(msg)}
+                        title="Delete message"
+                        aria-label="Delete message"
+                        className="text-gray-400 hover:text-red-500 cursor-pointer"
+                      >
+                        <FaTrash size={13} />
+                      </button>
+                    </div>
                   )}
                   <div
                     className={`px-4 py-2 rounded-lg max-w-xs ${
@@ -175,6 +210,34 @@ const ChatRoom = ({
                   >
                     {msg.isDeleted ? (
                       <div>This message was deleted</div>
+                    ) : isEditing ? (
+                      <div className="flex flex-col gap-2">
+                        <input
+                          type="text"
+                          value={editText}
+                          onChange={(e) => setEditText(e.target.value)}
+                          onKeyDown={(e) => {
+                            if (e.key === 'Enter') saveEditing(msg);
+                            if (e.key === 'Escape') cancelEditing();
+                          }}
+                          autoFocus
+                          className="px-2 py-1 rounded text-black dark:text-white bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 focus:outline-none"
+                        />
+                        <div className="flex gap-2 justify-end text-xs">
+                          <button
+                            onClick={() => saveEditing(msg)}
+                            className="px-2 py-1 rounded bg-white/20 hover:bg-white/30"
+                          >
+                            Save
+                          </button>
+                          <button
+                            onClick={cancelEditing}
+                            className="px-2 py-1 rounded bg-white/20 hover:bg-white/30"
+                          >
+                            Cancel
+                          </button>
+                        </div>
+                      </div>
                     ) : (
                       <>
                         <div>{msg.text}</div>
@@ -188,6 +251,11 @@ const ChatRoom = ({
                               onClick={() => openImageOverlay(url)}
                             />
                           ))}
+                        {msg.isEdited && (
+                          <span className="block text-[10px] opacity-70 mt-1">
+                            (edited)
+                          </span>
+                        )}
                       </>
                     )}
                   </div>

--- a/frontend/src/components/ChatRoom.jsx
+++ b/frontend/src/components/ChatRoom.jsx
@@ -1,6 +1,7 @@
 import gsap from 'gsap';
 import React, { useLayoutEffect, useRef, useState } from 'react';
 import { HiOutlinePhotograph } from 'react-icons/hi';
+import { FaTrash } from 'react-icons/fa';
 import { getLowResCloudinaryUrl } from '../utils/cloudinaryHelpers';
 
 const ChatRoom = ({
@@ -20,7 +21,14 @@ const ChatRoom = ({
   uploadedImageUrls,
   setUploadedImageUrls,
   handleMultipleImageUpload,
+  handleDeleteMessage,
 }) => {
+  const onDeleteClick = (msg) => {
+    if (window.confirm('Delete this message? This cannot be undone.')) {
+      handleDeleteMessage(msg);
+    }
+  };
+
   const [showImageOverlay, setShowImageOverlay] = useState(false);
   const [overlayImageUrl, setOverlayImageUrl] = useState(null);
   const overlayRef = useRef(null);
@@ -135,35 +143,57 @@ const ChatRoom = ({
                 No messages yet
               </div>
             )}
-            {messages.map((msg, idx) => (
-              <div
-                key={idx}
-                className={`mb-2 flex ${
-                  msg.senderId === user._id ? 'justify-end' : 'justify-start'
-                }`}
-                ref={idx === messages.length - 1 ? lastMessageRef : null}
-              >
+            {messages.map((msg, idx) => {
+              const isOwn = msg.senderId === user._id;
+              const canDelete = isOwn && msg._id && !msg.isDeleted;
+              return (
                 <div
-                  className={`px-4 py-2 rounded-lg max-w-xs ${
-                    msg.senderId === user._id
-                      ? 'bg-blue-600 text-white'
-                      : 'bg-gray-300 dark:bg-gray-700 text-black dark:text-white'
+                  key={msg._id || idx}
+                  className={`mb-2 flex items-center gap-2 group ${
+                    isOwn ? 'justify-end' : 'justify-start'
                   }`}
+                  ref={idx === messages.length - 1 ? lastMessageRef : null}
                 >
-                  <div>{msg.text}</div>
-                  {msg.imageUrls &&
-                    msg.imageUrls.map((url, i) => (
-                      <img
-                        key={i}
-                        src={getLowResCloudinaryUrl(url, 400, 200)}
-                        alt={`chat-img-${i}`}
-                        className="mt-2 w-40 h-40 object-cover rounded cursor-pointer"
-                        onClick={() => openImageOverlay(url)}
-                      />
-                    ))}
+                  {canDelete && (
+                    <button
+                      onClick={() => onDeleteClick(msg)}
+                      title="Delete message"
+                      aria-label="Delete message"
+                      className="opacity-0 group-hover:opacity-100 transition text-gray-400 hover:text-red-500 cursor-pointer"
+                    >
+                      <FaTrash size={14} />
+                    </button>
+                  )}
+                  <div
+                    className={`px-4 py-2 rounded-lg max-w-xs ${
+                      msg.isDeleted
+                        ? 'bg-gray-200 dark:bg-gray-800 text-gray-500 italic'
+                        : isOwn
+                          ? 'bg-blue-600 text-white'
+                          : 'bg-gray-300 dark:bg-gray-700 text-black dark:text-white'
+                    }`}
+                  >
+                    {msg.isDeleted ? (
+                      <div>This message was deleted</div>
+                    ) : (
+                      <>
+                        <div>{msg.text}</div>
+                        {msg.imageUrls &&
+                          msg.imageUrls.map((url, i) => (
+                            <img
+                              key={i}
+                              src={getLowResCloudinaryUrl(url, 400, 200)}
+                              alt={`chat-img-${i}`}
+                              className="mt-2 w-40 h-40 object-cover rounded cursor-pointer"
+                              onClick={() => openImageOverlay(url)}
+                            />
+                          ))}
+                      </>
+                    )}
+                  </div>
                 </div>
-              </div>
-            ))}
+              );
+            })}
             <div ref={messagesEndRef} />
           </div>
 


### PR DESCRIPTION
## Summary
Frontend for editing your own chat messages (child of #28), in both the patient and doctor chat UIs. Consumes the edit endpoint + socket from #29.

## Stacked PR
This is **based on `feat/delete-chat-frontend-27`** (#27) because both touch the same chat files; basing it there keeps this diff to just the edit changes and avoids a merge conflict. Once #27 merges to `main`, GitHub will auto-retarget this PR to `main`.

## Changes
**Patient app** — `frontend/src/Pages/Chat.jsx` + `components/ChatRoom.jsx`
- `handleEditMessage`: `PUT /api/v1/chat/edit/:id`, emit `editMessage` `{ chatRoomId, messageId, text }`, update local state.
- Listen for `messageEdited` to update content in real time.
- Pencil icon (hover) on own persisted, non-deleted messages → inline edit input with Save/Cancel (Enter = save, Esc = cancel).
- `(edited)` indicator shown on edited messages.

**Doctor app** — `docDashboard/src/components/Chat.jsx`
- Same edit handler, socket listener, inline-edit control and `(edited)` indicator for the doctor's own messages.

## Dependencies
- #29 (backend socket relay) merged.
- #27 (delete frontend) — this PR is stacked on it.

Part of #28 · Closes #30

## Test plan
- [ ] Patient edits own message inline → updates for patient and doctor live, shows "(edited)".
- [ ] Doctor edits own message → same, both sides.
- [ ] Esc/empty/unchanged cancels cleanly; no edit control on the other party's messages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)