### PR TITLE
Calm Clinical Teal — patient frontend revamp

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,6 +4,12 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700;800&display=swap"
+      rel="stylesheet"
+    />
     <title>MedHaven - Care Network</title>
   </head>
   <body>

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,13 +1,277 @@
 @import 'tailwindcss';
 
+/* Class-based dark mode: toggled by adding `.dark` to <html>. */
+@custom-variant dark (&:where(.dark, .dark *));
+
+@theme {
+  --font-sans: 'Plus Jakarta Sans', system-ui, sans-serif;
+
+  /* Calm Clinical Teal */
+  --color-teal-50: #eafbf8;
+  --color-teal-100: #cff4ee;
+  --color-teal-200: #9fe7dd;
+  --color-teal-300: #66d4c7;
+  --color-teal-400: #2fbdb2;
+  --color-teal-500: #0e9c92;
+  --color-teal-600: #0b7e76;
+  --color-teal-700: #0b5d5a;
+  --color-teal-800: #0f3f3d;
+  --color-teal-900: #0b2a29;
+
+  /* Warm sand accent */
+  --color-sand-300: #f8dda6;
+  --color-sand-400: #f2c078;
+  --color-sand-500: #e8a84f;
+
+  /* Dark surfaces */
+  --color-ink-900: #07201e;
+  --color-ink-800: #0e2c2a;
+  --color-ink-700: #14403c;
+  --color-ink-600: #1e5450;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  font-family: 'Plus Jakarta Sans', system-ui, sans-serif;
+  color: #0b2a29;
+  background: #f4fbfa;
+}
+
+.dark body {
+  color: #eafbf8;
+  background: #07201e;
+}
+
+/* ---- Ambient background ---- */
+.app-ambient {
+  position: fixed;
+  inset: 0;
+  z-index: -1;
+  transition: background 0.4s ease;
+  background:
+    radial-gradient(60rem 40rem at 12% -10%, rgba(102, 212, 199, 0.35), transparent 60%),
+    radial-gradient(50rem 40rem at 100% 10%, rgba(242, 192, 120, 0.3), transparent 55%),
+    radial-gradient(50rem 50rem at 50% 120%, rgba(14, 156, 146, 0.18), transparent 60%),
+    linear-gradient(180deg, #f4fbfa 0%, #eaf6f4 100%);
+}
+
+.dark .app-ambient {
+  background:
+    radial-gradient(55rem 38rem at 10% -10%, rgba(47, 189, 178, 0.22), transparent 60%),
+    radial-gradient(48rem 40rem at 100% 5%, rgba(11, 93, 90, 0.45), transparent 55%),
+    radial-gradient(55rem 55rem at 50% 120%, rgba(14, 156, 146, 0.16), transparent 60%),
+    linear-gradient(180deg, #07201e 0%, #051917 100%);
+}
+
+.grid-bg {
+  background-image: radial-gradient(rgba(14, 156, 146, 0.1) 1px, transparent 1px);
+  background-size: 22px 22px;
+}
+
+.dark .grid-bg {
+  background-image: radial-gradient(rgba(47, 189, 178, 0.1) 1px, transparent 1px);
+}
+
+.blob {
+  filter: blur(46px);
+  opacity: 0.55;
+}
+
+/* ---- Card depth ---- */
+.surface-card {
+  background: #fff;
+  border: 1px solid #cff4ee;
+  box-shadow: 0 10px 30px -14px rgba(11, 93, 90, 0.3);
+}
+
+.dark .surface-card {
+  background: linear-gradient(180deg, #103633 0%, #0c2a28 100%);
+  border-color: #1e5450;
+  box-shadow:
+    0 1px 0 0 rgba(159, 231, 221, 0.06) inset,
+    0 24px 50px -22px rgba(0, 0, 0, 0.7);
+}
+
+/* ---- Inputs ---- */
+.field {
+  width: 100%;
+  border-radius: 0.9rem;
+  border: 2px solid #cff4ee;
+  background: #fff;
+  padding: 0.7rem 0.95rem;
+  color: #0b2a29;
+  outline: none;
+  transition:
+    border-color 0.2s,
+    box-shadow 0.2s;
+}
+
+.field::placeholder {
+  color: #66d4c7;
+}
+
+.field:focus {
+  border-color: #0e9c92;
+  box-shadow: 0 0 0 4px rgba(14, 156, 146, 0.15);
+}
+
+.dark .field {
+  background: #0c2a28;
+  border-color: #1e5450;
+  color: #eafbf8;
+}
+
+.dark .field::placeholder {
+  color: #2fbdb2;
+}
+
+.dark .field:focus {
+  border-color: #2fbdb2;
+  box-shadow: 0 0 0 4px rgba(47, 189, 178, 0.18);
+}
+
+/* ---- Native select option contrast in dark ---- */
+.dark .field option {
+  background-color: #0c2a28;
+  color: #eafbf8;
+}
+
+/* ================= ANIMATIONS (pure CSS) ================= */
+@keyframes fadeUp {
+  from {
+    opacity: 0;
+    transform: translateY(30px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+@keyframes floaty {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-16px);
+  }
+}
+@keyframes pulseSoft {
+  0% {
+    box-shadow: 0 0 0 0 rgba(14, 156, 146, 0.5);
+  }
+  70% {
+    box-shadow: 0 0 0 16px rgba(14, 156, 146, 0);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(14, 156, 146, 0);
+  }
+}
+@keyframes marquee {
+  from {
+    transform: translateX(0);
+  }
+  to {
+    transform: translateX(-50%);
+  }
+}
+@keyframes beat {
+  0%,
+  100% {
+    transform: scale(1);
+  }
+  25% {
+    transform: scale(1.18);
+  }
+  40% {
+    transform: scale(1);
+  }
+}
+@keyframes dash {
+  to {
+    stroke-dashoffset: 0;
+  }
+}
+@keyframes glow {
+  0%,
+  100% {
+    opacity: 0.45;
+  }
+  50% {
+    opacity: 0.75;
+  }
+}
+@keyframes spinSlow {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.reveal {
+  opacity: 0;
+}
+.reveal.in {
+  animation: fadeUp 0.75s cubic-bezier(0.2, 0.7, 0.2, 1) forwards;
+}
+.anim-floaty {
+  animation: floaty 6s ease-in-out infinite;
+}
+.anim-pulse {
+  animation: pulseSoft 2.2s ease-out infinite;
+}
+.anim-beat {
+  animation: beat 1.6s ease-in-out infinite;
+}
+.anim-glow {
+  animation: glow 5s ease-in-out infinite;
+}
+.anim-spin {
+  animation: spinSlow 26s linear infinite;
+}
+.marquee {
+  animation: marquee 32s linear infinite;
+}
+.marquee:hover {
+  animation-play-state: paused;
+}
+.ekg path {
+  stroke-dasharray: 600;
+  stroke-dashoffset: 600;
+  animation: dash 2.4s ease-out forwards 0.2s;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .anim-floaty,
+  .anim-pulse,
+  .anim-beat,
+  .anim-glow,
+  .anim-spin,
+  .marquee {
+    animation: none !important;
+  }
+  .reveal {
+    opacity: 1 !important;
+  }
+  html {
+    scroll-behavior: auto;
+  }
+}
+
 .custom-scroll::-webkit-scrollbar {
   width: 6px;
   background: transparent;
 }
 
 .custom-scroll::-webkit-scrollbar-thumb {
-  background-color: #e0e5ec;
+  background-color: #9fe7dd;
   border-radius: 4px;
+}
+
+.dark .custom-scroll::-webkit-scrollbar-thumb {
+  background-color: #1e5450;
 }
 
 .custom-scroll::-webkit-scrollbar-track {
@@ -16,5 +280,5 @@
 
 .custom-scroll {
   scrollbar-width: thin;
-  scrollbar-color: #e0e5ec transparent;
+  scrollbar-color: #9fe7dd transparent;
 }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -47,6 +47,7 @@ const AppContent = () => {
 
   return (
     <>
+      <div className="app-ambient" aria-hidden="true" />
       {location.pathname !== '/chat' && <Navbar />}
 
       <Routes>

--- a/frontend/src/Pages/Chat.jsx
+++ b/frontend/src/Pages/Chat.jsx
@@ -6,6 +6,7 @@ import { io } from 'socket.io-client';
 import ChatList from '../components/ChatList';
 import ChatRoom from '../components/ChatRoom';
 import DoctorProfile from '../components/DoctorProfile';
+import ThemeToggle from '../components/ui/ThemeToggle';
 import { Context } from '../main';
 
 const socket = io(import.meta.env.VITE_BACKEND_URL, {
@@ -320,7 +321,12 @@ const Chat = () => {
   };
 
   return (
-    <div className="fixed inset-0 min-h-screen w-screen bg-gray-900 flex text-white">
+    <div className="fixed inset-0 flex min-h-screen w-screen bg-teal-50/60 text-teal-900 dark:bg-ink-900 dark:text-teal-50">
+      {/* Floating theme toggle (navbar is hidden on /chat) */}
+      <div className="absolute right-4 top-4 z-50">
+        <ThemeToggle className="bg-white/80 backdrop-blur dark:bg-ink-900/70" />
+      </div>
+
       {/* ChatList */}
       {(!isMobile || mobileViewMode === 'list') && (
         <ChatList
@@ -345,7 +351,7 @@ const Chat = () => {
               {isMobile && (
                 <button
                   onClick={onBackFromChatRoom}
-                  className="mb-2 px-4 py-2 rounded bg-blue-600 text-white font-bold self-start"
+                  className="mb-2 self-start rounded-xl bg-teal-500 px-4 py-2 font-bold text-white shadow-lg shadow-teal-500/30 transition hover:-translate-y-0.5 hover:bg-teal-600"
                 >
                   ← Back
                 </button>

--- a/frontend/src/Pages/EditAppointment.jsx
+++ b/frontend/src/Pages/EditAppointment.jsx
@@ -64,7 +64,11 @@ const EditAppointment = () => {
   };
 
   if (loading || !appt)
-    return <div className="text-center py-24">Loading appointment info...</div>;
+    return (
+      <div className="py-32 text-center font-semibold text-teal-700 dark:text-teal-200">
+        Loading appointment info...
+      </div>
+    );
 
   return (
     <AppointmentForm

--- a/frontend/src/Pages/ForgotPassword.jsx
+++ b/frontend/src/Pages/ForgotPassword.jsx
@@ -121,18 +121,18 @@ const ForgotPassword = () => {
   };
 
   return (
-    <section className="min-h-screen flex items-center justify-center bg-gradient-to-b from-blue-50 to-white dark:from-gray-900 dark:to-gray-950 px-4">
+    <section className="grid-bg flex min-h-screen items-center justify-center px-4 py-24">
       <div
         ref={formRef}
-        className="bg-white dark:bg-gray-900 rounded-2xl shadow-xl border border-gray-200 dark:border-gray-700 max-w-md w-full p-8"
+        className="surface-card w-full max-w-md rounded-3xl p-8"
       >
-        <h2 className="forgot-animate text-3xl font-bold text-center text-blue-700 dark:text-blue-400 mb-4">
+        <h2 className="forgot-animate mb-4 text-center text-3xl font-extrabold tracking-tight text-teal-900 dark:text-teal-50">
           Forgot Password
         </h2>
 
         {step === 1 && (
           <form onSubmit={requestOtp} className="space-y-5">
-            <p className="forgot-animate text-center text-gray-600 dark:text-gray-300 mb-2">
+            <p className="forgot-animate mb-2 text-center text-teal-700/80 dark:text-teal-100/70">
               Enter your registered email and we'll send you a one-time
               password to reset it.
             </p>
@@ -141,12 +141,12 @@ const ForgotPassword = () => {
               placeholder="Registered Email"
               value={email}
               onChange={(e) => setEmail(e.target.value)}
-              className="forgot-animate w-full px-4 py-3 border-2 border-white text-gray-900 dark:text-white bg-white dark:bg-gray-800 rounded-lg shadow-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500 placeholder-gray-500 dark:placeholder-gray-300"
+              className="forgot-animate field"
             />
             <button
               type="submit"
               disabled={loading}
-              className="forgot-animate w-full px-6 py-3 bg-blue-600 hover:bg-blue-700 text-white font-semibold rounded-full shadow-lg transform hover:scale-105 transition border-2 border-white disabled:opacity-50"
+              className="forgot-animate w-full rounded-2xl bg-teal-500 px-6 py-3.5 font-bold text-white shadow-lg shadow-teal-500/30 transition hover:-translate-y-0.5 hover:bg-teal-600 disabled:opacity-50"
             >
               {loading ? 'Sending...' : 'Send OTP'}
             </button>
@@ -155,7 +155,7 @@ const ForgotPassword = () => {
 
         {step === 2 && (
           <form onSubmit={continueToReset} className="space-y-5">
-            <p className="text-center text-gray-600 dark:text-gray-300 mb-2">
+            <p className="mb-2 text-center text-teal-700/80 dark:text-teal-100/70">
               Enter the OTP sent to <strong>{email}</strong>
             </p>
             <input
@@ -163,12 +163,12 @@ const ForgotPassword = () => {
               placeholder="Enter OTP"
               value={otp}
               onChange={(e) => setOtp(e.target.value)}
-              className="w-full px-4 py-3 text-gray-900 dark:text-white rounded-lg bg-white dark:bg-gray-800 border-2 border-white focus:ring-2 focus:ring-blue-500 outline-none transition placeholder-gray-500 dark:placeholder-gray-300"
+              className="field"
             />
             <div className="flex justify-between gap-3">
               <button
                 type="submit"
-                className="w-[48%] px-6 py-3 bg-blue-600 hover:bg-blue-700 text-white font-semibold rounded-full shadow-lg transform hover:scale-105 transition"
+                className="w-[48%] rounded-2xl bg-teal-500 px-6 py-3 font-bold text-white shadow-lg shadow-teal-500/30 transition hover:-translate-y-0.5 hover:bg-teal-600"
               >
                 Continue
               </button>
@@ -176,10 +176,10 @@ const ForgotPassword = () => {
                 type="button"
                 onClick={handleResendOtp}
                 disabled={resendCooldown > 0 || loading}
-                className={`w-[48%] px-6 py-3 rounded-full shadow-lg transform hover:scale-105 transition ${
+                className={`w-[48%] rounded-2xl px-6 py-3 font-bold transition hover:-translate-y-0.5 ${
                   resendCooldown > 0
-                    ? 'bg-gray-400 cursor-not-allowed text-white'
-                    : 'border border-blue-600 text-blue-600 hover:bg-blue-50'
+                    ? 'cursor-not-allowed border-2 border-teal-100 text-teal-400 dark:border-ink-600 dark:text-teal-200/50'
+                    : 'border-2 border-teal-200 text-teal-700 hover:border-teal-400 dark:border-ink-600 dark:text-teal-100'
                 }`}
               >
                 {resendCooldown > 0
@@ -192,7 +192,7 @@ const ForgotPassword = () => {
 
         {step === 3 && (
           <form onSubmit={resetPassword} className="space-y-5">
-            <p className="text-center text-gray-600 dark:text-gray-300 mb-2">
+            <p className="mb-2 text-center text-teal-700/80 dark:text-teal-100/70">
               Set a new password for <strong>{email}</strong>
             </p>
             <input
@@ -201,7 +201,7 @@ const ForgotPassword = () => {
               value={newPassword}
               onChange={(e) => setNewPassword(e.target.value)}
               autoComplete="new-password"
-              className="w-full px-4 py-3 text-gray-900 dark:text-white rounded-lg bg-white dark:bg-gray-800 border-2 border-white focus:ring-2 focus:ring-blue-500 outline-none transition placeholder-gray-500 dark:placeholder-gray-300"
+              className="field"
             />
             <input
               type="password"
@@ -209,25 +209,25 @@ const ForgotPassword = () => {
               value={confirmPassword}
               onChange={(e) => setConfirmPassword(e.target.value)}
               autoComplete="new-password"
-              className="w-full px-4 py-3 text-gray-900 dark:text-white rounded-lg bg-white dark:bg-gray-800 border-2 border-white focus:ring-2 focus:ring-blue-500 outline-none transition placeholder-gray-500 dark:placeholder-gray-300"
+              className="field"
             />
             <button
               type="submit"
               disabled={loading}
-              className="w-full px-6 py-3 bg-blue-600 hover:bg-blue-700 text-white font-semibold rounded-full shadow-lg transform hover:scale-105 transition border-2 border-white disabled:opacity-50"
+              className="w-full rounded-2xl bg-teal-500 px-6 py-3.5 font-bold text-white shadow-lg shadow-teal-500/30 transition hover:-translate-y-0.5 hover:bg-teal-600 disabled:opacity-50"
             >
               {loading ? 'Resetting...' : 'Reset Password'}
             </button>
           </form>
         )}
 
-        <div className="flex items-center justify-center text-sm gap-2 mt-6">
-          <span className="text-gray-700 dark:text-gray-200">
+        <div className="mt-6 flex items-center justify-center gap-2 text-sm">
+          <span className="text-teal-700/80 dark:text-teal-100/70">
             Remembered your password?
           </span>
           <Link
             to="/login"
-            className="text-blue-600 dark:text-blue-400 hover:underline"
+            className="font-semibold text-teal-600 hover:underline dark:text-teal-300"
           >
             Back to Login
           </Link>

--- a/frontend/src/Pages/Login.jsx
+++ b/frontend/src/Pages/Login.jsx
@@ -69,18 +69,24 @@ const Login = () => {
   }
 
   return (
-    <section className="min-h-screen flex items-center justify-center bg-gradient-to-b from-blue-50 to-white dark:from-gray-900 dark:to-gray-950 px-4">
+    <section className="grid-bg flex min-h-screen items-center justify-center px-4 py-24">
       <div
         ref={formRef}
-        className="bg-white dark:bg-gray-900 rounded-2xl shadow-xl border border-gray-200 dark:border-gray-700 max-w-md w-full p-8"
+        className="surface-card w-full max-w-md rounded-3xl p-8"
       >
-        <h2 className="login-animate text-3xl font-bold text-center text-blue-700 dark:text-blue-400 mb-4">
-          Sign In
+        <div className="login-animate mb-4 flex justify-center">
+          <span className="grid h-14 w-14 place-items-center rounded-2xl bg-teal-500 text-white shadow-lg shadow-teal-500/30">
+            <svg viewBox="0 0 24 24" className="h-7 w-7" fill="currentColor">
+              <path d="M11 2h2v9h9v2h-9v9h-2v-9H2v-2h9z" />
+            </svg>
+          </span>
+        </div>
+        <h2 className="login-animate mb-2 text-center text-3xl font-extrabold tracking-tight text-teal-900 dark:text-teal-50">
+          Welcome back
         </h2>
-        <p className="login-animate text-center text-gray-600 dark:text-gray-300 mb-6">
-          Welcome back to <span className="font-semibold">MedHaven</span>.
-          Please enter your details to log in to your account and manage your
-          appointments.
+        <p className="login-animate mb-6 text-center text-teal-700/80 dark:text-teal-100/70">
+          Sign in to <span className="font-semibold">MedHaven</span> to manage
+          your appointments and connect with your care team.
         </p>
 
         <form onSubmit={handleLogin} className="space-y-5">
@@ -89,32 +95,32 @@ const Login = () => {
             placeholder="Email Address"
             value={email}
             onChange={(e) => setEmail(e.target.value)}
-            className="login-animate w-full px-4 py-3 border-2 border-white text-gray-900 dark:text-white bg-white dark:bg-gray-800 rounded-lg shadow-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500 placeholder-gray-500 dark:placeholder-gray-300"
+            className="login-animate field"
           />
           <input
             type="password"
             placeholder="Password"
             value={password}
             onChange={(e) => setPassword(e.target.value)}
-            className="login-animate w-full px-4 py-3 border-2 border-white text-gray-900 dark:text-white bg-white dark:bg-gray-800 rounded-lg shadow-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500 placeholder-gray-500 dark:placeholder-gray-300"
+            className="login-animate field"
           />
 
           <div className="login-animate text-right text-sm">
             <Link
               to="/forgot-password"
-              className="text-blue-600 dark:text-blue-400 hover:underline"
+              className="font-semibold text-teal-600 hover:underline dark:text-teal-300"
             >
               Forgot Password?
             </Link>
           </div>
 
-          <div className="login-animate flex items-center justify-center text-sm gap-2">
-            <span className="text-gray-700 dark:text-gray-200">
+          <div className="login-animate flex items-center justify-center gap-2 text-sm">
+            <span className="text-teal-700/80 dark:text-teal-100/70">
               Not Registered?
             </span>
             <Link
               to="/register"
-              className="text-blue-600 dark:text-blue-400 hover:underline"
+              className="font-semibold text-teal-600 hover:underline dark:text-teal-300"
             >
               Register Now
             </Link>
@@ -122,7 +128,7 @@ const Login = () => {
           <div className="login-animate">
             <button
               type="submit"
-              className="w-full px-6 py-3 bg-blue-600 hover:bg-blue-700 text-white font-semibold rounded-full shadow-lg transform hover:scale-105 transition  border-2 border-white"
+              className="anim-pulse w-full rounded-2xl bg-teal-500 px-6 py-3.5 font-bold text-white shadow-lg shadow-teal-500/30 transition hover:-translate-y-0.5 hover:bg-teal-600"
             >
               Login
             </button>

--- a/frontend/src/Pages/MyAppointments.jsx
+++ b/frontend/src/Pages/MyAppointments.jsx
@@ -109,31 +109,33 @@ const MyAppointments = () => {
   };
 
   const getStatusClass = (status) => {
-    if (!status) return 'text-blue-600';
+    if (!status) return 'text-teal-600 font-semibold';
     switch (status.toLowerCase()) {
       case 'accepted':
-        return 'text-green-600 font-semibold';
+        return 'text-emerald-500 font-semibold';
       case 'rejected':
-        return 'text-red-600 font-semibold';
+        return 'text-rose-500 font-semibold';
       case 'updated':
-        return 'text-yellow-500 font-semibold';
+        return 'text-amber-500 font-semibold';
       case 'pending':
       default:
-        return 'text-blue-600 font-semibold';
+        return 'text-teal-600 dark:text-teal-300 font-semibold';
     }
   };
 
   return (
-    <div className="bg-gray-800 pt-3 text-gray-300">
-      <section className="max-w-5xl mx-auto p-4 min-h-96 bg-gray-800">
-        <h1 className="text-3xl font-bold text-center my-16 text-blue-700 dark:text-blue-400">
+    <div className="min-h-screen pt-20 text-teal-900 dark:text-teal-50">
+      <section className="mx-auto min-h-96 max-w-5xl p-4">
+        <h1 className="my-12 text-center text-3xl font-extrabold tracking-tight text-teal-900 dark:text-teal-50">
           My Appointments
         </h1>
 
         {loading ? (
-          <p className="text-center">Loading appointments...</p>
+          <p className="text-center text-teal-700/80 dark:text-teal-100/70">
+            Loading appointments...
+          </p>
         ) : appointments.length === 0 ? (
-          <p className="text-center text-gray-600 dark:text-gray-400">
+          <p className="text-center text-teal-700/70 dark:text-teal-200/60">
             No appointments found.
           </p>
         ) : (
@@ -141,35 +143,49 @@ const MyAppointments = () => {
             {appointments.map((appt) => (
               <div
                 key={appt._id}
-                className="appointment-card p-4 rounded-lg shadow-md bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 flex flex-col md:flex-row justify-between items-start md:items-center space-y-4 md:space-y-0"
+                className="appointment-card surface-card flex flex-col items-start justify-between space-y-4 rounded-3xl p-6 md:flex-row md:items-center md:space-y-0"
               >
-                <div className="flex-1">
+                <div className="flex-1 space-y-1 text-teal-800 dark:text-teal-100">
                   <p>
-                    <span className="font-semibold">Patient:</span>{' '}
+                    <span className="font-semibold text-teal-900 dark:text-teal-50">
+                      Patient:
+                    </span>{' '}
                     {appt.firstName} {appt.lastName}
                   </p>
                   <p>
-                    <span className="font-semibold">Appointment Date:</span>{' '}
+                    <span className="font-semibold text-teal-900 dark:text-teal-50">
+                      Appointment Date:
+                    </span>{' '}
                     {new Date(appt.appointment_date).toLocaleDateString()}
                   </p>
                   <p>
-                    <span className="font-semibold">Doctor:</span>{' '}
+                    <span className="font-semibold text-teal-900 dark:text-teal-50">
+                      Doctor:
+                    </span>{' '}
                     {appt.doctor.firstName} {appt.doctor.lastName}
                   </p>
                   <p>
-                    <span className="font-semibold">Department:</span>{' '}
+                    <span className="font-semibold text-teal-900 dark:text-teal-50">
+                      Department:
+                    </span>{' '}
                     {appt.department}
                   </p>
                   <p>
-                    <span className="font-semibold">Address:</span>{' '}
+                    <span className="font-semibold text-teal-900 dark:text-teal-50">
+                      Address:
+                    </span>{' '}
                     {appt.address}
                   </p>
                   <p>
-                    <span className="font-semibold">Visited Before:</span>{' '}
+                    <span className="font-semibold text-teal-900 dark:text-teal-50">
+                      Visited Before:
+                    </span>{' '}
                     {appt.hasVisited ? 'Yes' : 'No'}
                   </p>
                   <p>
-                    <span className="font-semibold">Status:</span>{' '}
+                    <span className="font-semibold text-teal-900 dark:text-teal-50">
+                      Status:
+                    </span>{' '}
                     <span className={getStatusClass(appt.status)}>
                       {appt.status || 'Pending'}
                     </span>
@@ -182,10 +198,10 @@ const MyAppointments = () => {
                     disabled={
                       !canDeleteOrEditAppointment(appt.appointment_date)
                     }
-                    className={`px-4 py-2 rounded-lg text-white font-semibold shadow-lg transition ${
+                    className={`rounded-xl px-5 py-2 font-bold text-white shadow-lg transition hover:-translate-y-0.5 ${
                       canDeleteOrEditAppointment(appt.appointment_date)
-                        ? 'bg-blue-600 hover:bg-blue-700 cursor-pointer'
-                        : 'bg-gray-500 cursor-not-allowed'
+                        ? 'cursor-pointer bg-teal-500 shadow-teal-500/30 hover:bg-teal-600'
+                        : 'cursor-not-allowed bg-teal-900/30 dark:bg-ink-600'
                     }`}
                     aria-label="Edit Appointment"
                     title={
@@ -204,10 +220,10 @@ const MyAppointments = () => {
                     disabled={
                       !canDeleteOrEditAppointment(appt.appointment_date)
                     }
-                    className={`px-4 py-2 rounded-lg text-white font-semibold shadow-lg transition ${
+                    className={`rounded-xl px-5 py-2 font-bold text-white shadow-lg transition hover:-translate-y-0.5 ${
                       canDeleteOrEditAppointment(appt.appointment_date)
-                        ? 'bg-red-600 hover:bg-red-700 cursor-pointer'
-                        : 'bg-gray-500 cursor-not-allowed'
+                        ? 'cursor-pointer bg-rose-500 shadow-rose-500/30 hover:bg-rose-600'
+                        : 'cursor-not-allowed bg-teal-900/30 dark:bg-ink-600'
                     }`}
                     aria-label="Delete Appointment"
                     title={

--- a/frontend/src/Pages/Profile.jsx
+++ b/frontend/src/Pages/Profile.jsx
@@ -112,11 +112,11 @@ const Profile = () => {
   };
 
   return (
-    <div className="min-h-screen flex flex-col items-center bg-gray-900 pt-20 sm:pt-30 text-white transition-colors duration-500">
+    <div className="flex min-h-screen flex-col items-center pt-24 text-teal-900 dark:text-teal-50 sm:pt-32">
       {/* Responsive Placeholder Avatar */}
-      <div className="w-24 h-24 sm:w-28 sm:h-28 rounded-full overflow-hidden bg-gray-700 flex justify-center items-center mb-4 sm:mb-6 shadow-md">
+      <div className="mb-4 flex h-24 w-24 items-center justify-center overflow-hidden rounded-full bg-gradient-to-br from-teal-400 to-teal-600 shadow-lg shadow-teal-500/30 sm:mb-6 sm:h-28 sm:w-28">
         <svg
-          className="w-14 h-14 sm:w-16 sm:h-16 text-gray-400"
+          className="h-14 w-14 text-white/90 sm:h-16 sm:w-16"
           fill="currentColor"
           viewBox="0 0 20 20"
         >
@@ -128,51 +128,62 @@ const Profile = () => {
         </svg>
       </div>
 
-      <hr className="w-9/12 max-w-md border-gray-600 mb-5 sm:mb-8" />
+      <hr className="mb-5 w-9/12 max-w-md border-teal-200/70 dark:border-ink-600 sm:mb-8" />
 
       {/* Personal Info Card: Responsive, scrollable on mobile */}
       <div
         ref={cardRef}
-        className="relative w-full max-w-md md:max-w-lg bg-gray-800 rounded-xl shadow-xl p-4 sm:p-6 pt-12 border border-gray-700 mx-2 sm:mx-0 flex flex-col"
+        className="surface-card relative mx-2 flex w-full max-w-md flex-col rounded-3xl p-4 pt-12 sm:p-6 md:max-w-lg sm:mx-0"
         style={{ minHeight: '375px' }}
       >
         {/* Pencil Icon edit button */}
-        <div className="absolute top-4 right-4 sm:top-3 sm:right-3">
+        <div className="absolute right-4 top-4 sm:right-3 sm:top-3">
           <button
-            className="text-blue-400 hover:text-blue-300 cursor-pointer transition-colors duration-200"
+            className="cursor-pointer text-teal-500 transition-colors duration-200 hover:text-teal-600 dark:text-teal-300 dark:hover:text-teal-200"
             title="Edit (disabled)"
           >
             <FaPencilAlt size={20} />
           </button>
         </div>
-        <h3 className="text-base sm:text-lg font-bold mb-4 sm:mb-5 text-center tracking-wide">
+        <h3 className="mb-4 text-center text-base font-bold tracking-wide text-teal-900 dark:text-teal-50 sm:mb-5 sm:text-lg">
           Personal information
         </h3>
-        <ul className="space-y-2 sm:space-y-3 text-sm sm:text-base flex-1">
+        <ul className="flex-1 space-y-2 text-sm text-teal-800 dark:text-teal-100 sm:space-y-3 sm:text-base">
           <li>
-            <span className="font-semibold">Full Name:</span> {user?.firstName}{' '}
-            {user?.lastName}
+            <span className="font-semibold text-teal-900 dark:text-teal-50">
+              Full Name:
+            </span>{' '}
+            {user?.firstName} {user?.lastName}
           </li>
           <li>
-            <span className="font-semibold">Date of Birth:</span>{' '}
+            <span className="font-semibold text-teal-900 dark:text-teal-50">
+              Date of Birth:
+            </span>{' '}
             {user?.dob ? user.dob.split('T')[0] : ''}
           </li>
           <li>
-            <span className="font-semibold">Gender:</span> {user?.gender}
+            <span className="font-semibold text-teal-900 dark:text-teal-50">
+              Gender:
+            </span>{' '}
+            {user?.gender}
           </li>
           <li>
-            <span className="font-semibold">Email:</span>{' '}
+            <span className="font-semibold text-teal-900 dark:text-teal-50">
+              Email:
+            </span>{' '}
             {maskEmail(user?.email)}
           </li>
           <li>
-            <span className="font-semibold">Phone Number:</span>{' '}
+            <span className="font-semibold text-teal-900 dark:text-teal-50">
+              Phone Number:
+            </span>{' '}
             {'+91 ' + maskPhone(user?.phone)}
           </li>
         </ul>
         {/* Change Password Button, left bottom */}
-        <div className="absolute left-4 bottom-4">
+        <div className="absolute bottom-4 left-4">
           <button
-            className="flex items-center gap-2 text-blue-400 hover:text-blue-300 cursor-pointer font-semibold py-2 px-2 transition"
+            className="flex cursor-pointer items-center gap-2 px-2 py-2 font-semibold text-teal-600 transition hover:text-teal-700 dark:text-teal-300 dark:hover:text-teal-200"
             onClick={() => {
               resetPasswordForm();
               setShowPasswordModal(true);
@@ -183,9 +194,9 @@ const Profile = () => {
           </button>
         </div>
         {/* Logout Button, right bottom */}
-        <div className="absolute right-4 bottom-4">
+        <div className="absolute bottom-4 right-4">
           <button
-            className="flex items-center gap-2 text-red-500 hover:text-red-600 cursor-pointer font-semibold py-2 px-2 transition"
+            className="flex cursor-pointer items-center gap-2 px-2 py-2 font-semibold text-rose-500 transition hover:text-rose-600"
             onClick={() => setShowLogoutModal(true)}
           >
             <FaSignOutAlt size={16} />
@@ -196,14 +207,16 @@ const Profile = () => {
 
       {/* Change Password Modal */}
       {showPasswordModal && (
-        <div className="fixed inset-0 flex items-center justify-center z-50">
+        <div className="fixed inset-0 z-50 flex items-center justify-center">
           <div
-            className="absolute inset-0 bg-opacity-40 backdrop-blur-sm transition-all duration-300"
+            className="absolute inset-0 bg-teal-950/40 backdrop-blur-sm transition-all duration-300 dark:bg-black/50"
             onClick={() => !passwordLoading && setShowPasswordModal(false)}
           ></div>
-          <div className="relative bg-gray-800 rounded-2xl shadow-2xl px-6 py-8 w-[360px] max-w-sm z-60 border border-gray-700">
-            <FaLock className="mx-auto text-3xl text-blue-400 mb-3" />
-            <p className="text-lg font-bold mb-5 text-center">Change Password</p>
+          <div className="surface-card relative z-60 w-[360px] max-w-sm rounded-3xl px-6 py-8">
+            <FaLock className="mx-auto mb-3 text-3xl text-teal-500 dark:text-teal-300" />
+            <p className="mb-5 text-center text-lg font-bold text-teal-900 dark:text-teal-50">
+              Change Password
+            </p>
             <form onSubmit={submitPasswordChange} className="flex flex-col gap-4">
               <input
                 type="password"
@@ -211,7 +224,7 @@ const Profile = () => {
                 placeholder="Old Password"
                 value={passwordForm.oldPassword}
                 onChange={handlePasswordChange}
-                className="px-3 py-2 rounded bg-gray-700 border border-gray-600 text-white focus:outline-none focus:border-blue-400"
+                className="field"
                 autoComplete="current-password"
               />
               <input
@@ -220,7 +233,7 @@ const Profile = () => {
                 placeholder="New Password"
                 value={passwordForm.newPassword}
                 onChange={handlePasswordChange}
-                className="px-3 py-2 rounded bg-gray-700 border border-gray-600 text-white focus:outline-none focus:border-blue-400"
+                className="field"
                 autoComplete="new-password"
               />
               <input
@@ -229,13 +242,13 @@ const Profile = () => {
                 placeholder="Confirm New Password"
                 value={passwordForm.confirmPassword}
                 onChange={handlePasswordChange}
-                className="px-3 py-2 rounded bg-gray-700 border border-gray-600 text-white focus:outline-none focus:border-blue-400"
+                className="field"
                 autoComplete="new-password"
               />
-              <div className="flex justify-center gap-4 mt-2">
+              <div className="mt-2 flex justify-center gap-4">
                 <button
                   type="button"
-                  className="px-4 py-2 rounded text-gray-300 border border-gray-500 font-semibold hover:bg-gray-600 transition"
+                  className="rounded-xl border-2 border-teal-200 px-4 py-2 font-semibold text-teal-700 transition hover:border-teal-400 dark:border-ink-600 dark:text-teal-100"
                   onClick={() => setShowPasswordModal(false)}
                   disabled={passwordLoading}
                 >
@@ -243,7 +256,7 @@ const Profile = () => {
                 </button>
                 <button
                   type="submit"
-                  className="px-4 py-2 rounded text-blue-400 border border-blue-400 font-semibold hover:bg-blue-500 hover:text-white transition disabled:opacity-50"
+                  className="rounded-xl bg-teal-500 px-4 py-2 font-semibold text-white shadow-lg shadow-teal-500/30 transition hover:-translate-y-0.5 hover:bg-teal-600 disabled:opacity-50"
                   disabled={passwordLoading}
                 >
                   {passwordLoading ? 'Saving...' : 'Update'}
@@ -256,27 +269,27 @@ const Profile = () => {
 
       {/* Logout Confirmation Modal */}
       {showLogoutModal && (
-        <div className="fixed inset-0 flex items-center justify-center z-50">
+        <div className="fixed inset-0 z-50 flex items-center justify-center">
           {/* Blurred background */}
           <div
-            className="absolute inset-0 bg-opacity-40 backdrop-blur-sm transition-all duration-300"
+            className="absolute inset-0 bg-teal-950/40 backdrop-blur-sm transition-all duration-300 dark:bg-black/50"
             onClick={() => setShowLogoutModal(false)}
           ></div>
-          <div className="relative bg-gray-800 rounded-2xl shadow-2xl px-6 py-8 w-[320px] max-w-xs text-center z-60 border border-gray-700">
-            <FaSignOutAlt className="mx-auto text-3xl text-red-500 mb-3" />
-            <p className="text-lg font-bold mb-4">
+          <div className="surface-card relative z-60 w-[320px] max-w-xs rounded-3xl px-6 py-8 text-center">
+            <FaSignOutAlt className="mx-auto mb-3 text-3xl text-rose-500" />
+            <p className="mb-4 text-lg font-bold text-teal-900 dark:text-teal-50">
               Are you sure you want to logout?
             </p>
-            <div className="flex justify-center gap-4 mt-2">
+            <div className="mt-2 flex justify-center gap-4">
               <button
-                className="px-4 py-2 rounded text-blue-500 border border-blue-500 font-semibold hover:bg-blue-500 hover:text-white transition"
+                className="rounded-xl border-2 border-teal-200 px-4 py-2 font-semibold text-teal-700 transition hover:border-teal-400 dark:border-ink-600 dark:text-teal-100"
                 onClick={() => setShowLogoutModal(false)}
                 disabled={loading}
               >
                 No
               </button>
               <button
-                className="px-4 py-2 rounded text-red-500 border border-red-500 font-semibold hover:bg-red-500 hover:text-white transition"
+                className="rounded-xl bg-rose-500 px-4 py-2 font-semibold text-white shadow-lg shadow-rose-500/30 transition hover:-translate-y-0.5 hover:bg-rose-600"
                 onClick={doLogout}
                 disabled={loading}
               >

--- a/frontend/src/Pages/Register.jsx
+++ b/frontend/src/Pages/Register.jsx
@@ -166,15 +166,15 @@ const Register = () => {
   };
 
   return (
-    <section className="text-white min-h-screen flex items-center justify-center bg-gradient-to-b from-blue-50 to-white dark:from-gray-900 dark:to-gray-950 px-4">
+    <section className="grid-bg flex min-h-screen items-center justify-center px-4 py-24">
       <div
         ref={formRef}
-        className="bg-white dark:bg-gray-900 rounded-2xl shadow-xl border border-gray-200 dark:border-gray-700 max-w-2xl w-full p-8"
+        className="surface-card w-full max-w-2xl rounded-3xl p-8"
       >
-        <h2 className="register-animate text-3xl font-bold text-center text-blue-700 dark:text-blue-400 mb-4">
+        <h2 className="register-animate mb-2 text-center text-3xl font-extrabold tracking-tight text-teal-900 dark:text-teal-50">
           Create Your Account
         </h2>
-        <p className="register-animate text-center text-gray-600 dark:text-gray-300 mb-8">
+        <p className="register-animate mb-8 text-center text-teal-700/80 dark:text-teal-100/70">
           Join <span className="font-semibold">MedHaven</span> today. Book
           appointments, access health records, and connect with our medical
           team—securely and easily.
@@ -192,14 +192,14 @@ const Register = () => {
                   placeholder="First Name"
                   value={firstName}
                   onChange={(e) => setFirstName(e.target.value)}
-                  className="register-animate input-field"
+                  className="register-animate field"
                 />
                 <input
                   type="text"
                   placeholder="Last Name"
                   value={lastName}
                   onChange={(e) => setLastName(e.target.value)}
-                  className="register-animate input-field"
+                  className="register-animate field"
                 />
               </div>
 
@@ -210,14 +210,14 @@ const Register = () => {
                   placeholder="Email Address"
                   value={email}
                   onChange={(e) => setEmail(e.target.value)}
-                  className="register-animate input-field"
+                  className="register-animate field"
                 />
                 <input
                   type="number"
                   placeholder="Mobile Number"
                   value={phone}
                   onChange={(e) => setPhone(e.target.value)}
-                  className="register-animate input-field"
+                  className="register-animate field"
                 />
               </div>
 
@@ -230,7 +230,7 @@ const Register = () => {
                     placeholderText="Date of Birth"
                     maxDate={new Date()}
                     dateFormat="dd/MM/yyyy"
-                    className=" input-field w-full px-4 py-3 text-gray-900 dark:text-white rounded-lg  bg-white dark:bg-gray-900 focus:ring-2 focus:ring-blue-500 focus:border-white outline-none transition placeholder-gray-500 dark:placeholder-gray-300"
+                    className="field"
                     showMonthDropdown
                     showYearDropdown
                     dropdownMode="select"
@@ -239,7 +239,7 @@ const Register = () => {
                 <select
                   value={gender}
                   onChange={(e) => setGender(e.target.value)}
-                  className="register-animate input-field select-dark"
+                  className="register-animate field"
                 >
                   <option value="">Select Gender</option>
                   <option value="Male">Male</option>
@@ -254,18 +254,18 @@ const Register = () => {
                   placeholder="Create Password"
                   value={password}
                   onChange={(e) => setPassword(e.target.value)}
-                  className="register-animate input-field"
+                  className="register-animate field"
                 />
               </div>
 
               {/* Already Registered */}
-              <div className="register-animate flex items-center justify-center text-sm gap-2">
-                <span className="text-gray-700 dark:text-gray-200">
+              <div className="register-animate flex items-center justify-center gap-2 text-sm">
+                <span className="text-teal-700/80 dark:text-teal-100/70">
                   Already Registered?
                 </span>
                 <Link
                   to="/login"
-                  className="text-blue-600 dark:text-blue-400 hover:underline"
+                  className="font-semibold text-teal-600 hover:underline dark:text-teal-300"
                 >
                   Login Now
                 </Link>
@@ -273,7 +273,7 @@ const Register = () => {
               <div className="register-animate text-center">
                 <button
                   type="submit"
-                  className="w-full px-6 py-3 bg-blue-600 hover:bg-blue-700 text-white font-semibold rounded-full shadow-lg transform hover:scale-105 transition  border-2 border-white"
+                  className="anim-pulse w-full rounded-2xl bg-teal-500 px-6 py-3.5 font-bold text-white shadow-lg shadow-teal-500/30 transition hover:-translate-y-0.5 hover:bg-teal-600"
                 >
                   Continue
                 </button>
@@ -283,7 +283,7 @@ const Register = () => {
 
           {step === 2 && (
             <>
-              <p className="text-center mb-4 text-gray-700 dark:text-gray-300">
+              <p className="mb-4 text-center text-teal-700/80 dark:text-teal-100/70">
                 Enter the OTP sent to <strong>{tempUserData?.email}</strong>
               </p>
               <input
@@ -291,12 +291,12 @@ const Register = () => {
                 placeholder="Enter OTP"
                 value={otp}
                 onChange={(e) => setOtp(e.target.value)}
-                className="input-field w-full px-4 py-3 text-gray-900 dark:text-white rounded-lg bg-white dark:bg-gray-900 focus:ring-2 focus:ring-blue-500 focus:border-white outline-none transition placeholder-gray-500 dark:placeholder-gray-300"
+                className="field"
               />
-              <div className="flex justify-between mt-4">
+              <div className="mt-4 flex justify-between gap-3">
                 <button
                   type="submit"
-                  className="w-[48%] px-6 py-3 bg-blue-600 hover:bg-blue-700 text-white font-semibold rounded-full shadow-lg transform hover:scale-105 transition"
+                  className="w-[48%] rounded-2xl bg-teal-500 px-6 py-3 font-bold text-white shadow-lg shadow-teal-500/30 transition hover:-translate-y-0.5 hover:bg-teal-600"
                 >
                   Verify OTP
                 </button>
@@ -304,8 +304,11 @@ const Register = () => {
                   type="button"
                   onClick={handleResendOtp}
                   disabled={resendCooldown > 0}
-                  className={`w-[48%] px-6 py-3 rounded-full shadow-lg transform hover:scale-105 transition 
-                    ${resendCooldown > 0 ? 'bg-gray-400 cursor-not-allowed' : 'border border-blue-600 text-blue-600 hover:bg-blue-50'}`}
+                  className={`w-[48%] rounded-2xl px-6 py-3 font-bold transition hover:-translate-y-0.5 ${
+                    resendCooldown > 0
+                      ? 'cursor-not-allowed border-2 border-teal-100 text-teal-400 dark:border-ink-600 dark:text-teal-200/50'
+                      : 'border-2 border-teal-200 text-teal-700 hover:border-teal-400 dark:border-ink-600 dark:text-teal-100'
+                  }`}
                 >
                   {resendCooldown > 0
                     ? `Resend OTP in ${resendCooldown}s`
@@ -316,20 +319,6 @@ const Register = () => {
           )}
         </form>
       </div>
-
-      <style>{`
-        .input-field {
-          border-radius: 10px; 
-          padding: 10px;
-        }
-        .select-dark option {
-          background-color: #1f2937;
-          color: white;
-        }
-        .react-datepicker-popper {
-          z-index: !important;
-        }
-      `}</style>
     </section>
   );
 };

--- a/frontend/src/components/AppointmentForm.jsx
+++ b/frontend/src/components/AppointmentForm.jsx
@@ -142,13 +142,10 @@ const AppointmentForm = ({
   };
 
   return (
-    <section className="text-white relative py-20 bg-gradient-to-b from-blue-50 to-white dark:from-gray-900 dark:to-gray-950">
-      <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div
-          ref={formRef}
-          className="bg-white dark:bg-gray-900 rounded-2xl border border-gray-200 dark:border-gray-700 shadow-lg p-8 md:p-12"
-        >
-          <h2 className="form-animate text-3xl font-bold text-center text-blue-700 dark:text-blue-400 mb-10">
+    <section className="relative py-20">
+      <div className="mx-auto max-w-5xl px-4 sm:px-6 lg:px-8">
+        <div ref={formRef} className="surface-card rounded-3xl p-8 md:p-12">
+          <h2 className="form-animate mb-10 text-center text-3xl font-bold text-teal-900 dark:text-teal-50">
             {isEdit ? 'Edit Appointment' : 'Book Your Appointment'}
           </h2>
 
@@ -161,7 +158,7 @@ const AppointmentForm = ({
                 placeholder="First Name"
                 value={form.firstName}
                 onChange={handleChange}
-                className="form-animate input-field"
+                className="form-animate field"
               />
               <input
                 name="lastName"
@@ -169,7 +166,7 @@ const AppointmentForm = ({
                 placeholder="Last Name"
                 value={form.lastName}
                 onChange={handleChange}
-                className="form-animate input-field"
+                className="form-animate field"
               />
             </div>
 
@@ -181,7 +178,7 @@ const AppointmentForm = ({
                 placeholder="Email"
                 value={form.email}
                 onChange={handleChange}
-                className="form-animate input-field"
+                className="form-animate field"
               />
               <input
                 name="phone"
@@ -189,7 +186,7 @@ const AppointmentForm = ({
                 placeholder="Mobile Number"
                 value={form.phone}
                 onChange={handleChange}
-                className="form-animate input-field"
+                className="form-animate field"
               />
             </div>
 
@@ -206,7 +203,7 @@ const AppointmentForm = ({
                 placeholderText="Date of Birth"
                 maxDate={new Date()}
                 dateFormat="dd/MM/yyyy"
-                className="input-field form-animate"
+                className="field form-animate"
                 showMonthDropdown
                 showYearDropdown
                 dropdownMode="select"
@@ -219,7 +216,7 @@ const AppointmentForm = ({
                 name="gender"
                 value={form.gender}
                 onChange={handleChange}
-                className="form-animate input-field select-dark hover:cursor-pointer"
+                className="form-animate field hover:cursor-pointer"
               >
                 <option value="">Select Gender</option>
                 <option value="Male">Male</option>
@@ -240,7 +237,7 @@ const AppointmentForm = ({
                 placeholderText="Appointment Date"
                 minDate={new Date()}
                 dateFormat="dd/MM/yyyy"
-                className="input-field form-animate"
+                className="field form-animate"
                 showMonthDropdown
                 showYearDropdown
                 dropdownMode="select"
@@ -253,7 +250,7 @@ const AppointmentForm = ({
                 name="department"
                 value={form.department}
                 onChange={handleChange}
-                className="form-animate input-field select-dark hover:cursor-pointer"
+                className="form-animate field hover:cursor-pointer"
               >
                 {departmentsArray.map((depart, index) => (
                   <option value={depart} key={index}>
@@ -264,7 +261,7 @@ const AppointmentForm = ({
               <select
                 value={`${form.doctor_firstName} ${form.doctor_lastName}`}
                 onChange={handleDoctorChange}
-                className="form-animate input-field select-dark hover:cursor-pointer"
+                className="form-animate field hover:cursor-pointer"
                 disabled={!form.department}
               >
                 <option value="">Select Doctor</option>
@@ -288,12 +285,12 @@ const AppointmentForm = ({
               placeholder="Address"
               value={form.address}
               onChange={handleChange}
-              className="form-animate input-field resize-none w-full"
+              className="form-animate field resize-none"
             />
 
             {/* Visited Before */}
             <div className="form-animate flex items-center space-x-3">
-              <label className="text-gray-700 dark:text-gray-200">
+              <label className="text-teal-700/80 dark:text-teal-100/70">
                 Visited before?
               </label>
               <input
@@ -301,22 +298,26 @@ const AppointmentForm = ({
                 type="checkbox"
                 checked={form.hasVisited}
                 onChange={handleChange}
-                className="w-5 h-5"
+                className="h-5 w-5 accent-teal-500"
               />
             </div>
 
             {/* Submit Button */}
-            <div className="form-animate text-center flex flex-col md:flex-row md:justify-center md:space-x-4">
+            <div className="form-animate flex flex-col text-center md:flex-row md:justify-center md:space-x-4">
               <button
                 type="submit"
-                className={`px-8 py-3 ${isEdit ? 'w-1/2 bg-yellow-500 hover:bg-yellow-600' : 'w-full bg-blue-600 hover:bg-blue-700'} text-white font-semibold rounded-full shadow-lg transform hover:scale-105 cursor-pointer transition border-2 border-white`}
+                className={`rounded-2xl px-8 py-3.5 font-bold text-white shadow-lg transition hover:-translate-y-0.5 ${
+                  isEdit
+                    ? 'w-full bg-sand-500 shadow-sand-500/30 hover:bg-sand-400 md:w-1/2'
+                    : 'anim-pulse w-full bg-teal-500 shadow-teal-500/30 hover:bg-teal-600'
+                }`}
               >
                 {submitText}
               </button>
               {isEdit && (
                 <button
                   type="button"
-                  className="w-1/2 px-8 py-3 mt-4 md:mt-0 bg-gray-500 hover:bg-gray-600 cursor-pointer text-white font-semibold rounded-full shadow-lg transform hover:scale-105 transition border-2 border-white"
+                  className="mt-4 w-full rounded-2xl border-2 border-teal-200 px-8 py-3.5 font-bold text-teal-700 transition hover:-translate-y-0.5 hover:border-teal-400 dark:border-ink-600 dark:text-teal-100 md:mt-0 md:w-1/2"
                   onClick={onCancel}
                 >
                   Cancel
@@ -325,21 +326,6 @@ const AppointmentForm = ({
             </div>
           </form>
         </div>
-
-        <style>{`
-          .input-field {
-            padding: 10px;
-            border-radius: 10px;
-          }
-          .input-field::placeholder {
-            color: white !important;
-            opacity: 1;
-          }
-          .select-dark option {
-            background-color: #1f2937;
-            color: white;
-          }
-        `}</style>
       </div>
     </section>
   );

--- a/frontend/src/components/Biography.jsx
+++ b/frontend/src/components/Biography.jsx
@@ -60,48 +60,48 @@ const Biography = ({ imageUrl }) => {
   }, []);
 
   return (
-    <section ref={bioRef} className="py-16 bg-blue-50 dark:bg-gray-950">
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex flex-col lg:flex-row gap-12 items-center biography">
-        <div className="bio-image flex-shrink-0 lg:w-1/3 flex justify-center">
+    <section ref={bioRef} className="py-20">
+      <div className="biography mx-auto flex max-w-7xl flex-col items-center gap-12 px-4 sm:px-6 lg:flex-row lg:px-8">
+        <div className="bio-image flex flex-shrink-0 justify-center lg:w-1/3">
           <img
             src={imageUrl}
             alt="Who We Are"
-            className="w-64 h-64 object-cover rounded-2xl border-4 border-blue-200 shadow-lg"
+            className="h-64 w-64 rounded-[2rem] border-4 border-teal-200 object-cover shadow-xl shadow-teal-600/20 dark:border-ink-600"
           />
         </div>
         <div className="bio-header lg:w-2/3">
-          <p className="bio-title text-cyan-600 font-semibold mb-3 text-lg tracking-wide">
+          <p className="bio-title mb-3 text-lg font-semibold tracking-wide text-teal-500">
             Biography
           </p>
-          <h3 className="bio-title text-3xl sm:text-4xl font-bold text-blue-800 dark:text-blue-400 mb-4">
+          <h3 className="bio-title mb-4 text-3xl font-bold text-teal-900 dark:text-teal-50 sm:text-4xl">
             Who We Are
           </h3>
           <div className="space-y-4">
-            <p className="bio-desc text-gray-700 dark:text-gray-300 text-lg">
+            <p className="bio-desc text-lg text-teal-700/80 dark:text-teal-100/70">
               MedHaven is a comprehensive hospital management platform built
               with the MERN stack. Our mission is to simplify patient care,
               streamline hospital operations, and empower medical professionals
               through innovative technology.
             </p>
-            <p className="bio-desc text-gray-700 dark:text-gray-300 text-lg">
+            <p className="bio-desc text-lg text-teal-700/80 dark:text-teal-100/70">
               As a modern healthcare solution, MedHaven enables clinics and
               hospitals to manage appointments, patient records, and
               practitioner workflows all in one place. We believe in the power
               of secure, easy-to-use tools that make a difference in both
               frontline patient care and backend administration.
             </p>
-            <p className="bio-desc text-blue-700 dark:text-blue-400 font-medium">
+            <p className="bio-desc font-medium text-teal-600 dark:text-teal-300">
               Our team is passionate about coding, healthcare, and delivering
               real-world impact in 2024 and beyond!
             </p>
-            <p className="bio-desc text-gray-700 dark:text-gray-300 text-lg">
+            <p className="bio-desc text-lg text-teal-700/80 dark:text-teal-100/70">
               From patient registration to record-keeping and secure
               communication, every module in MedHaven is designed for
               reliability, privacy, and speed. We are committed to helping care
               providers save time, reduce errors, and focus on what matters
               most: their patients.
             </p>
-            <p className="bio-desc text-cyan-500 dark:text-cyan-400 font-semibold">
+            <p className="bio-desc font-semibold text-sand-500">
               MedHaven is made for today’s hospitals and tomorrow’s innovators.
             </p>
           </div>

--- a/frontend/src/components/ChatList.jsx
+++ b/frontend/src/components/ChatList.jsx
@@ -15,32 +15,34 @@ const ChatList = ({
   <div
     className={`${
       isMobile && isActiveView ? 'w-full' : 'w-1/3'
-    } bg-white dark:bg-gray-800 flex flex-col p-4 overflow-hidden custom-scroll`}
+    } custom-scroll flex flex-col overflow-hidden border-r border-teal-100 bg-white p-4 text-teal-900 dark:border-ink-600 dark:bg-ink-900 dark:text-teal-50`}
   >
     <button
-      className="mb-4 px-4 py-2 rounded bg-blue-600 hover:cursor-pointer text-white font-bold self-start"
+      className="mb-4 self-start rounded-xl bg-teal-500 px-4 py-2 font-bold text-white shadow-lg shadow-teal-500/30 transition hover:-translate-y-0.5 hover:cursor-pointer hover:bg-teal-600"
       onClick={() => navigate('/')}
     >
       ← Back
     </button>
-    <h2 className="font-bold text-lg mb-2 text-blue-700 dark:text-blue-400">
+    <h2 className="mb-2 text-lg font-bold text-teal-700 dark:text-teal-300">
       Chats
     </h2>
-    <div className="flex-1 overflow-y-auto pr-2 custom-scroll">
+    <div className="custom-scroll flex-1 overflow-y-auto pr-2">
       {Object.keys(departments).length === 0 && (
-        <div className="text-gray-500 py-8">No doctors available for chat</div>
+        <div className="py-8 text-teal-700/60 dark:text-teal-200/50">
+          No doctors available for chat
+        </div>
       )}
       {Object.entries(departments).map(([dept, doctors]) => (
         <div key={dept}>
           {/* Folder header */}
           <div
             onClick={() => toggleDepartment(dept)}
-            className="flex items-center cursor-pointer px-2 py-2 rounded transition hover:bg-gray-100 dark:hover:bg-gray-900 select-none font-semibold text-base"
+            className="flex cursor-pointer select-none items-center rounded-xl px-2 py-2 text-base font-semibold transition hover:bg-teal-50 dark:hover:bg-ink-600/40"
           >
             {departmentsOpen[dept] ? (
-              <FaFolderMinus className="text-blue-600 mr-2" size={22} />
+              <FaFolderMinus className="mr-2 text-teal-500" size={22} />
             ) : (
-              <FaFolderPlus className="text-blue-600 mr-2" size={22} />
+              <FaFolderPlus className="mr-2 text-teal-500" size={22} />
             )}
             <span>{dept}</span>
           </div>
@@ -50,10 +52,10 @@ const ChatList = ({
               {doctors.map((doc) => (
                 <li
                   key={doc.id}
-                  className={`cursor-pointer flex items-center gap-2 px-2 py-2 mb-1 rounded transition ${
+                  className={`mb-1 flex cursor-pointer items-center gap-2 rounded-xl px-2 py-2 transition ${
                     selectedChat?.id === doc.id
-                      ? 'bg-blue-100 dark:bg-blue-900'
-                      : 'hover:bg-gray-100 dark:hover:bg-gray-900'
+                      ? 'bg-teal-100 dark:bg-teal-900/40'
+                      : 'hover:bg-teal-50 dark:hover:bg-ink-600/40'
                   }`}
                   onClick={() => setSelectedChat(doc)}
                 >

--- a/frontend/src/components/ChatRoom.jsx
+++ b/frontend/src/components/ChatRoom.jsx
@@ -135,7 +135,7 @@ const ChatRoom = ({
   return (
     <div
       ref={containerRef}
-      className="flex-1 flex flex-col bg-gray-100 dark:bg-gray-950 p-4 overflow-hidden"
+      className="flex-1 flex flex-col bg-teal-50/40 dark:bg-ink-900 text-teal-900 dark:text-teal-50 p-4 overflow-hidden"
       style={{ paddingBottom: '50px' }}
     >
       {selectedChat ? (
@@ -155,7 +155,7 @@ const ChatRoom = ({
               <div className="w-12 h-12 bg-gray-400 rounded-full" />
             )}
             <h3 className="text-xl font-semibold">{selectedChat.name}</h3>
-            <span className="text-xs bg-blue-100 text-blue-800 px-2 py-1 rounded dark:bg-blue-900 dark:text-blue-200">
+            <span className="rounded-full bg-teal-100 px-2 py-1 text-xs font-medium text-teal-800 dark:bg-teal-900/50 dark:text-teal-200">
               {selectedChat.department}
             </span>
           </div>
@@ -163,7 +163,7 @@ const ChatRoom = ({
           {/* Messages */}
           <div className="flex-1 overflow-y-auto mb-4 pr-2 custom-scroll">
             {messages.length === 0 && (
-              <div className="text-gray-500 text-center mt-8">
+              <div className="mt-8 text-center text-teal-700/60 dark:text-teal-200/50">
                 No messages yet
               </div>
             )}
@@ -185,7 +185,7 @@ const ChatRoom = ({
                         onClick={() => startEditing(msg)}
                         title="Edit message"
                         aria-label="Edit message"
-                        className="text-gray-400 hover:text-blue-500 cursor-pointer"
+                        className="cursor-pointer text-teal-400 hover:text-teal-600"
                       >
                         <FaPencilAlt size={13} />
                       </button>
@@ -193,19 +193,19 @@ const ChatRoom = ({
                         onClick={() => onDeleteClick(msg)}
                         title="Delete message"
                         aria-label="Delete message"
-                        className="text-gray-400 hover:text-red-500 cursor-pointer"
+                        className="cursor-pointer text-teal-400 hover:text-rose-500"
                       >
                         <FaTrash size={13} />
                       </button>
                     </div>
                   )}
                   <div
-                    className={`px-4 py-2 rounded-lg max-w-xs ${
+                    className={`max-w-xs rounded-2xl px-4 py-2 ${
                       msg.isDeleted
-                        ? 'bg-gray-200 dark:bg-gray-800 text-gray-500 italic'
+                        ? 'bg-teal-100/70 italic text-teal-600 dark:bg-ink-600/40 dark:text-teal-200/60'
                         : isOwn
-                          ? 'bg-blue-600 text-white'
-                          : 'bg-gray-300 dark:bg-gray-700 text-black dark:text-white'
+                          ? 'bg-teal-500 text-white shadow-md shadow-teal-500/20'
+                          : 'bg-white text-teal-900 shadow-sm dark:bg-ink-600 dark:text-teal-50'
                     }`}
                   >
                     {msg.isDeleted ? (
@@ -221,7 +221,7 @@ const ChatRoom = ({
                             if (e.key === 'Escape') cancelEditing();
                           }}
                           autoFocus
-                          className="px-2 py-1 rounded text-black dark:text-white bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 focus:outline-none"
+                          className="rounded-lg border border-teal-200 bg-white px-2 py-1 text-teal-900 focus:outline-none dark:border-ink-600 dark:bg-ink-900 dark:text-teal-50"
                         />
                         <div className="flex gap-2 justify-end text-xs">
                           <button
@@ -267,7 +267,7 @@ const ChatRoom = ({
 
           {/* Uploaded images preview above input controls */}
           {uploadedImageUrls.length > 0 && (
-            <div className="flex space-x-2 overflow-x-auto p-2 bg-gray-200 dark:bg-gray-800 rounded-t-lg mb-2">
+            <div className="mb-2 flex space-x-2 overflow-x-auto rounded-t-2xl bg-teal-100/70 p-2 dark:bg-ink-600/50">
               {uploadedImageUrls.map((url, idx) => (
                 <div key={idx} className="relative">
                   <img
@@ -301,13 +301,13 @@ const ChatRoom = ({
           />
 
           {/* Input controls fixed at bottom */}
-          <div className="fixed bottom-0 right-0 bg-gray-100 dark:bg-gray-950 w-full md:w-2/3 p-2 shadow-inner z-40 rounded-t-lg">
+          <div className="fixed bottom-0 right-0 z-40 w-full rounded-t-2xl bg-teal-50/90 p-2 shadow-inner backdrop-blur dark:bg-ink-900/90 md:w-2/3">
             <div className="flex items-center gap-2">
               <input
                 type="text"
                 value={input}
                 onChange={(e) => setInput(e.target.value)}
-                className="flex-1 px-4 py-2 rounded-lg border bg-white dark:bg-gray-800 text-black dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-600"
+                className="flex-1 rounded-xl border-2 border-teal-200 bg-white px-4 py-2 text-teal-900 focus:border-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-400/40 dark:border-ink-600 dark:bg-ink-900 dark:text-teal-50"
                 placeholder="Type your message"
                 onKeyDown={(e) => {
                   if (e.key === 'Enter') handleSend();
@@ -316,7 +316,7 @@ const ChatRoom = ({
               />
               <button
                 onClick={onImageIconClick}
-                className="p-2 rounded-lg bg-blue-600 hover:bg-blue-700 cursor-pointer text-white"
+                className="cursor-pointer rounded-xl bg-teal-500 p-2 text-white shadow-lg shadow-teal-500/30 transition hover:-translate-y-0.5 hover:bg-teal-600"
                 title="Upload Image"
               >
                 <HiOutlinePhotograph size={24} />
@@ -324,10 +324,10 @@ const ChatRoom = ({
               <button
                 onClick={handleSend}
                 disabled={sendingDisabled}
-                className={`px-4 py-2 rounded-lg font-semibold hover:cursor-pointer text-white ${
+                className={`rounded-xl px-4 py-2 font-semibold text-white transition hover:cursor-pointer ${
                   sendingDisabled
-                    ? 'bg-blue-300 cursor-not-allowed'
-                    : 'bg-blue-600 hover:bg-blue-700'
+                    ? 'cursor-not-allowed bg-teal-300'
+                    : 'bg-teal-500 shadow-lg shadow-teal-500/30 hover:-translate-y-0.5 hover:bg-teal-600'
                 }`}
               >
                 Send
@@ -339,7 +339,7 @@ const ChatRoom = ({
           {showImageOverlay && (
             <div
               ref={overlayRef}
-              className="fixed inset-0 flex items-center justify-center z-50 backdrop-blur-sm bg-opacity-70"
+              className="fixed inset-0 z-50 flex items-center justify-center bg-teal-950/50 backdrop-blur-sm dark:bg-black/70"
               onClick={closeOverlay}
             >
               {/* Close button */}

--- a/frontend/src/components/Departments.jsx
+++ b/frontend/src/components/Departments.jsx
@@ -85,26 +85,31 @@ const Departments = () => {
   }, []);
 
   return (
-    <section className="py-16 bg-white dark:bg-gray-900">
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 overflow-hidden">
-        <h2 className="text-4xl font-extrabold text-blue-700 dark:text-blue-400 mb-10 text-center">
-          Departments
-        </h2>
+    <section className="py-20">
+      <div className="mx-auto max-w-7xl overflow-hidden px-4 sm:px-6 lg:px-8">
+        <div className="mb-10 text-center">
+          <span className="inline-flex items-center gap-2 rounded-full bg-teal-100 px-4 py-1.5 text-sm font-semibold text-teal-700 dark:bg-ink-700 dark:text-teal-200">
+            Our Specialities
+          </span>
+          <h2 className="mt-4 text-3xl font-extrabold tracking-tight text-teal-900 dark:text-teal-50 sm:text-4xl">
+            Departments
+          </h2>
+        </div>
 
         <div className="overflow-hidden">
           <div ref={wrapperRef} className="flex">
             {departmentsArray.map((depart, index) => (
               <div
                 key={index}
-                className="dept-card flex-shrink-0 w-64 bg-blue-50 dark:bg-gray-800 rounded-2xl shadow-md overflow-hidden mr-6"
+                className="dept-card surface-card mr-6 w-64 flex-shrink-0 overflow-hidden rounded-3xl transition hover:-translate-y-1"
               >
                 <img
                   src={depart.imageUrl}
                   alt={`${depart.name} Department`}
-                  className="w-full h-40 object-cover"
+                  className="h-40 w-full object-cover"
                 />
                 <div className="p-4">
-                  <h3 className="text-xl font-semibold text-blue-800 dark:text-blue-300 text-center">
+                  <h3 className="text-center text-xl font-semibold text-teal-800 dark:text-teal-200">
                     {depart.name}
                   </h3>
                 </div>

--- a/frontend/src/components/DoctorProfile.jsx
+++ b/frontend/src/components/DoctorProfile.jsx
@@ -66,12 +66,12 @@ const DoctorProfile = ({ doctor, onBack }) => {
     <>
       <div
         ref={containerRef}
-        className="flex-1 flex flex-col p-6 bg-white dark:bg-gray-900 overflow-y-auto text-gray-900 dark:text-gray-100"
+        className="flex-1 flex flex-col p-6 bg-white dark:bg-ink-900 overflow-y-auto text-teal-900 dark:text-teal-50"
       >
         {/* Back Button */}
         <button
           onClick={onBack}
-          className="mb-4 px-4 py-2 rounded bg-blue-600 hover:cursor-pointer text-white font-bold self-start"
+          className="mb-4 self-start rounded-xl bg-teal-500 px-4 py-2 font-bold text-white shadow-lg shadow-teal-500/30 transition hover:-translate-y-0.5 hover:cursor-pointer hover:bg-teal-600"
         >
           ← Back
         </button>
@@ -91,14 +91,14 @@ const DoctorProfile = ({ doctor, onBack }) => {
           <h2 className="text-2xl font-bold">
             {doctor.name || `${doctor.firstName} ${doctor.lastName}`}
           </h2>
-          <p className="text-blue-600 dark:text-blue-400 mt-1 font-medium">
+          <p className="mt-1 font-medium text-teal-600 dark:text-teal-300">
             {doctor.department || doctor.doctorDepartment}
           </p>
         </div>
 
         {/* Doctor Details */}
         <div className="mt-6 w-full">
-          <h3 className="text-lg font-semibold mb-2 text-gray-700 dark:text-gray-300">
+          <h3 className="mb-2 text-lg font-semibold text-teal-700 dark:text-teal-200">
             Profile Details
           </h3>
           <div className="grid grid-cols-1 gap-y-2 md:grid-cols-2 md:gap-x-10">
@@ -130,7 +130,7 @@ const DoctorProfile = ({ doctor, onBack }) => {
       {showImageOverlay && (
         <div
           ref={overlayRef}
-          className="fixed inset-0 flex items-center justify-center z-50 backdrop-blur-sm  bg-opacity-30"
+          className="fixed inset-0 z-50 flex items-center justify-center bg-teal-950/50 backdrop-blur-sm dark:bg-black/70"
           onClick={closeOverlay}
         >
           {/* Close button fixed top-right */}

--- a/frontend/src/components/Footer.jsx
+++ b/frontend/src/components/Footer.jsx
@@ -41,44 +41,50 @@ const Footer = () => {
   return (
     <footer
       ref={footerRef}
-      className="bg-white dark:bg-gray-900 border-t border-blue-100 dark:border-gray-800  pt-32 pb-4"
+      className="border-t border-teal-100 bg-white/70 pb-4 pt-32 backdrop-blur dark:border-ink-700 dark:bg-ink-900/70"
     >
-      <div className="max-w-7xl mx-auto px-4 md:px-8">
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-8 text-gray-700 dark:text-gray-200 mb-8">
+      <div className="mx-auto max-w-7xl px-4 md:px-8">
+        <div className="mb-8 grid grid-cols-1 gap-8 text-teal-800 dark:text-teal-100 sm:grid-cols-2 lg:grid-cols-4">
           <div className="footer-section flex flex-col items-start">
-            <img
-              src="/logo.png"
-              alt="MedHaven Logo"
-              className="h-12 object-contain mb-3 rounded-lg shadow-sm "
-            />
-            <span className="text-xl font-bold text-blue-600 dark:text-blue-400 tracking-tight">
-              MedHaven
+            <span className="mb-3 flex items-center gap-2.5">
+              <span className="grid h-9 w-9 place-items-center rounded-xl bg-teal-500 text-white shadow-lg shadow-teal-500/30">
+                <svg
+                  viewBox="0 0 24 24"
+                  className="h-5 w-5"
+                  fill="currentColor"
+                >
+                  <path d="M11 2h2v9h9v2h-9v9h-2v-9H2v-2h9z" />
+                </svg>
+              </span>
+              <span className="text-xl font-extrabold tracking-tight text-teal-900 dark:text-teal-50">
+                Med<span className="text-teal-500">Haven</span>
+              </span>
             </span>
-            <span className="mt-2 text-sm text-gray-500 dark:text-gray-400">
-              Modern Hospital Management
+            <span className="mt-2 text-sm text-teal-700/70 dark:text-teal-200/70">
+              Compassionate care, close to you.
             </span>
           </div>
 
           <div className="footer-section">
-            <h4 className="font-semibold text-blue-700 dark:text-blue-400 mb-4 text-lg">
+            <h4 className="mb-4 text-lg font-semibold text-teal-700 dark:text-teal-300">
               Quick Links
             </h4>
             <ul className="space-y-2">
               <li>
-                <Link to="/" className="hover:text-blue-600 transition">
+                <Link to="/" className="transition hover:text-teal-500">
                   Home
                 </Link>
               </li>
               <li>
                 <Link
                   to="/appointment"
-                  className="hover:text-blue-600 transition"
+                  className="transition hover:text-teal-500"
                 >
                   Appointment
                 </Link>
               </li>
               <li>
-                <Link to="/about" className="hover:text-blue-600 transition">
+                <Link to="/about" className="transition hover:text-teal-500">
                   About
                 </Link>
               </li>
@@ -86,14 +92,14 @@ const Footer = () => {
           </div>
 
           <div className="footer-section">
-            <h4 className="font-semibold text-blue-700 dark:text-blue-400 mb-4 text-lg">
+            <h4 className="mb-4 text-lg font-semibold text-teal-700 dark:text-teal-300">
               Hours
             </h4>
             <ul className="space-y-2">
               {hours.map((element) => (
                 <li key={element.id} className="flex justify-between text-sm">
                   <span>{element.day}</span>
-                  <span className="text-gray-500 dark:text-gray-400">
+                  <span className="text-teal-700/60 dark:text-teal-200/60">
                     {element.time}
                   </span>
                 </li>
@@ -102,31 +108,31 @@ const Footer = () => {
           </div>
 
           <div className="footer-section">
-            <h4 className="font-semibold text-blue-700 dark:text-blue-400 mb-4 text-lg">
+            <h4 className="mb-4 text-lg font-semibold text-teal-700 dark:text-teal-300">
               Contact
             </h4>
-            <div className="flex items-center gap-3 mb-3">
-              <FaPhone className="text-blue-500" />
+            <div className="mb-3 flex items-center gap-3">
+              <FaPhone className="text-teal-500" />
               <span className="text-sm">+91 75899-77592</span>
             </div>
-            <div className="flex items-center gap-3 mb-3">
-              <MdEmail className="text-blue-500" />
+            <div className="mb-3 flex items-center gap-3">
+              <MdEmail className="text-teal-500" />
               <span className="text-sm">divesh.contact@gmail.com</span>
             </div>
             <div className="flex items-center gap-3">
-              <FaLocationArrow className="text-blue-500" />
+              <FaLocationArrow className="text-teal-500" />
               <span className="text-sm">Rajpura, Punjab, India</span>
             </div>
           </div>
         </div>
 
-        <hr className="border-blue-100 dark:border-gray-800 mb-6" />
-        <div className="flex flex-col md:flex-row items-center justify-between text-sm text-gray-500 dark:text-gray-400">
+        <hr className="mb-6 border-teal-100 dark:border-ink-700" />
+        <div className="flex flex-col items-center justify-between text-sm text-teal-700/60 dark:text-teal-200/60 md:flex-row">
           <span>
             © {new Date().getFullYear()} MedHaven. All rights reserved.
           </span>
           <span>
-            Crafted with <span className="text-blue-500">❤️</span> by Divesh
+            Crafted with <span className="text-rose-400">❤</span> by Divesh
             Saini
           </span>
         </div>

--- a/frontend/src/components/Hero.jsx
+++ b/frontend/src/components/Hero.jsx
@@ -1,4 +1,5 @@
 import React, { useRef } from 'react';
+import { Link } from 'react-router-dom';
 import { useGSAP } from '@gsap/react';
 import gsap from 'gsap';
 
@@ -29,27 +30,74 @@ const Hero = ({ title, imageUrl }) => {
   );
 
   return (
-    <section ref={heroRef} className="bg-white dark:bg-gray-900 py-28">
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 grid grid-cols-1 lg:grid-cols-12 gap-8 items-center">
-        <div className="lg:col-span-7 mb-12 lg:mb-0">
-          <h1 className="hero-title text-4xl font-extrabold text-blue-700 dark:text-blue-400 sm:text-5xl">
+    <section
+      ref={heroRef}
+      className="relative overflow-hidden grid-bg pt-28 pb-20"
+    >
+      <div className="blob anim-glow absolute -left-24 -top-10 h-72 w-72 rounded-full bg-teal-300 dark:bg-teal-600" />
+      <div className="blob anim-glow absolute right-0 top-32 h-80 w-80 rounded-full bg-sand-400/70" />
+
+      <div className="mx-auto grid max-w-7xl grid-cols-1 items-center gap-10 px-4 sm:px-6 lg:grid-cols-12 lg:px-8">
+        <div className="lg:col-span-7">
+          <span className="hero-title inline-flex items-center gap-2 rounded-full bg-teal-100 px-4 py-1.5 text-sm font-semibold text-teal-700 dark:bg-ink-700 dark:text-teal-200">
+            <span className="anim-beat inline-block text-teal-500">❤</span>
+            Trusted healthcare, close to you
+          </span>
+          <h1 className="hero-title mt-6 text-4xl font-extrabold leading-tight tracking-tight text-teal-900 dark:text-teal-50 sm:text-5xl">
             {title}
           </h1>
-          <p className="hero-desc mt-6 max-w-3xl text-lg text-gray-600 dark:text-gray-300">
+          <p className="hero-desc mt-6 max-w-2xl text-lg text-teal-700/80 dark:text-teal-100/70">
             MedHaven Medical Institute is a state-of-the-art facility dedicated
             to providing comprehensive healthcare services with compassion and
-            expertise. Our team of skilled professionals is committed to
-            delivering personalized care tailored to each patient's needs. At
-            MedHaven, we prioritize your well-being, ensuring a harmonious
-            journey towards optimal health and wellness.
+            expertise. Our skilled team delivers personalized care tailored to
+            each patient's needs — ensuring a harmonious journey towards optimal
+            health and wellness.
           </p>
+          <div className="hero-desc mt-8 flex flex-wrap gap-3">
+            <Link
+              to="/appointment"
+              className="anim-pulse rounded-2xl bg-teal-500 px-7 py-3.5 font-bold text-white shadow-lg shadow-teal-500/30 transition hover:-translate-y-0.5 hover:bg-teal-600"
+            >
+              Book an Appointment
+            </Link>
+            <Link
+              to="/about"
+              className="rounded-2xl border-2 border-teal-200 px-7 py-3.5 font-bold text-teal-700 transition hover:-translate-y-0.5 hover:border-teal-400 dark:border-ink-600 dark:text-teal-100"
+            >
+              Learn More
+            </Link>
+          </div>
+          <svg
+            className="ekg mt-10 h-9 w-full max-w-md text-teal-400"
+            viewBox="0 0 400 40"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="3"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <path d="M0 20 H110 l10 -14 14 28 12 -22 9 14 H400" />
+          </svg>
         </div>
-        <div className="lg:col-span-5 relative flex justify-center items-center">
-          <img
-            src={imageUrl}
-            alt="Hero"
-            className="hero-image w-full max-w-md rounded-lghidden lg:block"
-          />
+
+        <div className="relative flex items-center justify-center lg:col-span-5">
+          {imageUrl ? (
+            <img
+              src={imageUrl}
+              alt="Hero"
+              className="hero-image anim-floaty w-full max-w-md rounded-[2rem] shadow-2xl shadow-teal-600/30"
+            />
+          ) : (
+            <div className="hero-image anim-floaty mx-auto grid h-72 w-72 place-items-center rounded-[2.5rem] bg-gradient-to-br from-teal-400 to-teal-600 text-white shadow-2xl shadow-teal-600/40">
+              <svg
+                viewBox="0 0 24 24"
+                className="h-32 w-32 opacity-90"
+                fill="currentColor"
+              >
+                <path d="M12 2a5 5 0 0 1 5 5v2a5 5 0 0 1-10 0V7a5 5 0 0 1 5-5Zm-7 18a7 7 0 0 1 14 0v2H5v-2Z" />
+              </svg>
+            </div>
+          )}
         </div>
       </div>
     </section>

--- a/frontend/src/components/MessageForm.jsx
+++ b/frontend/src/components/MessageForm.jsx
@@ -96,13 +96,13 @@ const MessageForm = () => {
   };
 
   return (
-    <section className="text-white relative py-20 bg-gradient-to-b from-blue-50 to-white dark:from-gray-900 dark:to-gray-950">
-      <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+    <section className="relative py-20">
+      <div className="mx-auto max-w-4xl px-4 sm:px-6 lg:px-8">
         <div
           ref={formRef}
-          className="bg-white dark:bg-gray-900 rounded-2xl border border-gray-200 dark:border-gray-700 shadow-lg p-8 md:p-12"
+          className="surface-card rounded-3xl p-8 md:p-12"
         >
-          <h2 className="form-animate text-3xl font-bold text-center text-blue-700 dark:text-blue-400 mb-10">
+          <h2 className="form-animate mb-10 text-center text-3xl font-bold text-teal-900 dark:text-teal-50">
             Send Us A Message
           </h2>
 
@@ -114,14 +114,14 @@ const MessageForm = () => {
                 placeholder="First Name"
                 value={firstName}
                 onChange={(e) => setFirstName(e.target.value)}
-                className="form-animate input-field"
+                className="form-animate field"
               />
               <input
                 type="text"
                 placeholder="Last Name"
                 value={lastName}
                 onChange={(e) => setLastName(e.target.value)}
-                className="form-animate input-field"
+                className="form-animate field"
               />
             </div>
 
@@ -132,14 +132,14 @@ const MessageForm = () => {
                 placeholder="Email"
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
-                className="form-animate input-field"
+                className="form-animate field"
               />
               <input
                 type="tel"
                 placeholder="Mobile Number"
                 value={phone}
                 onChange={(e) => setPhone(e.target.value)}
-                className="form-animate input-field"
+                className="form-animate field"
               />
             </div>
 
@@ -156,7 +156,7 @@ const MessageForm = () => {
                     setDepartment('');
                   }
                 }}
-                className="form-animate input-field select-dark"
+                className="form-animate field"
               >
                 <option value="Doctor">Doctor</option>
                 <option value="Admin">Admin</option>
@@ -173,7 +173,7 @@ const MessageForm = () => {
                     setDoctorFirstName('');
                     setDoctorLastName('');
                   }}
-                  className="form-animate input-field select-dark hover:cursor-pointer"
+                  className="form-animate field hover:cursor-pointer"
                 >
                   <option value="">Select Department</option>
                   {departmentsArray.map((depart, index) => (
@@ -189,7 +189,7 @@ const MessageForm = () => {
                     setDoctorFirstName(firstName);
                     setDoctorLastName(lastName || '');
                   }}
-                  className="form-animate input-field select-dark hover:cursor-pointer"
+                  className="form-animate field hover:cursor-pointer"
                   disabled={!department}
                 >
                   <option value="">Select Doctor</option>
@@ -213,14 +213,14 @@ const MessageForm = () => {
               placeholder="Write your message here..."
               value={message}
               onChange={(e) => setMessage(e.target.value)}
-              className="p-3 form-animate input-field resize-none w-full"
+              className="form-animate field resize-none"
             />
 
             {/* Submit */}
-            <div className="text-center form-animate">
+            <div className="form-animate text-center">
               <button
                 type="submit"
-                className=" px-8 py-3 bg-blue-600 hover:bg-blue-700 cursor-pointer text-white font-semibold rounded-full shadow-lg transform hover:scale-105 transition w-full border-2 border-white"
+                className="anim-pulse w-full rounded-2xl bg-teal-500 px-8 py-3.5 font-bold text-white shadow-lg shadow-teal-500/30 transition hover:-translate-y-0.5 hover:bg-teal-600"
               >
                 Send Message
               </button>
@@ -228,29 +228,6 @@ const MessageForm = () => {
           </form>
         </div>
       </div>
-
-      <style>{`
-        .input-field {
-          padding: 10px;
-          width: 100%;
-          }
-        .input-field::placeholder {
-          color: white !important;
-          opacity: 1;
-        }
-        .select-dark {
-          background-color: bg-gray-800;
-          color: white;
-        }
-        .select-dark.dark\\:bg-gray-700 {
-          background-color: #374151 !important;
-          color: white;
-        }
-        select option {
-          background-color: #1f2937;
-          color: white;
-        }
-      `}</style>
     </section>
   );
 };

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -7,6 +7,7 @@ import { toast } from 'react-toastify';
 import { Context } from '../main';
 import { useGSAP } from '@gsap/react';
 import gsap from 'gsap';
+import ThemeToggle from './ui/ThemeToggle';
 
 const Navbar = () => {
   const [show, setShow] = useState(false);
@@ -66,70 +67,81 @@ const Navbar = () => {
   // Hide navbar on /chat route
   if (location.pathname === '/chat') return null;
 
+  const linkClass = (to) =>
+    `rounded-lg px-3 py-2 text-sm font-semibold transition ${
+      location.pathname === to
+        ? 'bg-teal-100 text-teal-700 dark:bg-ink-700 dark:text-teal-200'
+        : 'text-teal-700 hover:bg-teal-50 dark:text-teal-100 dark:hover:bg-ink-700'
+    }`;
+
   return (
     <nav
       ref={navbarRef}
-      className="backdrop-blur bg-white/80 dark:bg-gray-900/80 border-b border-blue-50 dark:border-gray-800 fixed w-full z-50 shadow-lg"
+      className="fixed z-50 w-full border-b border-teal-100/80 bg-white/75 backdrop-blur dark:border-ink-700 dark:bg-ink-900/75"
     >
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div className="flex items-center justify-between py-4">
-          <Link to="/" className="flex items-center gap-3">
-            <span className="font-bold text-blue-700 text-xl tracking-tight block">
-              MedHaven
+      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+        <div className="flex items-center justify-between py-3.5">
+          <Link to="/" className="flex items-center gap-2.5">
+            <span className="grid h-9 w-9 place-items-center rounded-xl bg-teal-500 text-white shadow-lg shadow-teal-500/30">
+              <svg viewBox="0 0 24 24" className="h-5 w-5" fill="currentColor">
+                <path d="M11 2h2v9h9v2h-9v9h-2v-9H2v-2h9z" />
+              </svg>
+            </span>
+            <span className="text-xl font-extrabold tracking-tight text-teal-900 dark:text-teal-50">
+              Med<span className="text-teal-500">Haven</span>
             </span>
           </Link>
-          <div className="hidden md:flex items-center space-x-8">
+
+          <div className="hidden items-center gap-1 md:flex">
             {visibleLinks.map((link) => (
-              <Link
-                key={link.to}
-                to={link.to}
-                className={`font-medium px-3 py-2 rounded-md transition text-base ${
-                  location.pathname === link.to
-                    ? 'text-blue-700 underline underline-offset-4'
-                    : 'text-gray-700 dark:text-gray-200 hover:text-blue-700'
-                }`}
-              >
+              <Link key={link.to} to={link.to} className={linkClass(link.to)}>
                 {link.label}
               </Link>
             ))}
           </div>
 
-          <div className="hidden md:flex">
+          <div className="hidden items-center gap-3 md:flex">
+            <ThemeToggle />
             {isAuthenticated ? (
               <Link to="/profile" className="flex items-center justify-center">
-                <FaUserCircle className="text-blue-700 dark:text-blue-300 text-3xl hover:text-blue-500 transition" />
+                <FaUserCircle className="text-3xl text-teal-600 transition hover:text-teal-500 dark:text-teal-300" />
               </Link>
             ) : (
               <button
                 onClick={goToLogin}
-                className="px-5 py-2 rounded-xl bg-cyan-500 text-white hover:bg-cyan-600 transition font-semibold shadow"
+                className="rounded-xl bg-teal-500 px-5 py-2 text-sm font-bold text-white shadow-lg shadow-teal-500/30 transition hover:bg-teal-600"
               >
-                LOGIN
+                Login
               </button>
             )}
           </div>
 
           {/* Hamburger */}
-          <button
-            className="md:hidden text-blue-700 dark:text-blue-300 text-3xl rounded-md focus:outline-none transition"
-            onClick={() => setShow((prev) => !prev)}
-          >
-            <GiHamburgerMenu />
-          </button>
+          <div className="flex items-center gap-2 md:hidden">
+            <ThemeToggle />
+            <button
+              className="rounded-lg p-2 text-3xl text-teal-600 transition dark:text-teal-300"
+              onClick={() => setShow((prev) => !prev)}
+              aria-label="Toggle menu"
+            >
+              <GiHamburgerMenu />
+            </button>
+          </div>
         </div>
       </div>
+
       {/* Mobile Drawer */}
       {show && (
-        <div className="md:hidden bg-white dark:bg-gray-900 border-t shadow-lg px-6 py-6 space-y-5">
+        <div className="space-y-4 border-t border-teal-100 bg-white px-6 py-6 dark:border-ink-700 dark:bg-ink-900 md:hidden">
           {visibleLinks.map((link) => (
             <Link
               key={link.to}
               to={link.to}
               onClick={() => setShow(false)}
-              className={`block font-semibold text-lg px-2 py-2 rounded ${
+              className={`block rounded-lg px-2 py-2 text-lg font-semibold ${
                 location.pathname === link.to
-                  ? 'text-blue-700 underline underline-offset-4'
-                  : 'text-gray-700 dark:text-gray-200 hover:text-blue-700'
+                  ? 'bg-teal-100 text-teal-700 dark:bg-ink-700 dark:text-teal-200'
+                  : 'text-teal-700 hover:bg-teal-50 dark:text-teal-100 dark:hover:bg-ink-700'
               }`}
             >
               {link.label}
@@ -141,7 +153,7 @@ const Navbar = () => {
               onClick={() => setShow(false)}
               className="flex w-full items-center justify-center py-2"
             >
-              <FaUserCircle className="text-blue-700 dark:text-blue-300 text-3xl hover:text-blue-500 transition" />
+              <FaUserCircle className="text-3xl text-teal-600 transition hover:text-teal-500 dark:text-teal-300" />
             </Link>
           ) : (
             <button
@@ -149,9 +161,9 @@ const Navbar = () => {
                 goToLogin();
                 setShow(false);
               }}
-              className="w-full px-5 py-2 rounded-xl bg-cyan-500 text-white hover:bg-cyan-600 transition font-semibold shadow"
+              className="w-full rounded-xl bg-teal-500 px-5 py-2 font-bold text-white shadow-lg shadow-teal-500/30 transition hover:bg-teal-600"
             >
-              LOGIN
+              Login
             </button>
           )}
         </div>

--- a/frontend/src/components/ui/Button.jsx
+++ b/frontend/src/components/ui/Button.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+
+const VARIANTS = {
+  primary:
+    'bg-teal-500 text-white shadow-lg shadow-teal-500/30 hover:bg-teal-600 disabled:bg-teal-300',
+  outline:
+    'border-2 border-teal-200 text-teal-700 hover:border-teal-400 dark:border-ink-600 dark:text-teal-100 dark:hover:border-teal-400',
+  sand: 'bg-sand-400 text-teal-900 shadow-lg shadow-sand-400/30 hover:bg-sand-500',
+  danger: 'bg-rose-500 text-white shadow-lg shadow-rose-500/30 hover:bg-rose-600',
+  ghost:
+    'text-teal-700 hover:bg-teal-50 dark:text-teal-100 dark:hover:bg-ink-700',
+};
+
+const Button = ({
+  variant = 'primary',
+  className = '',
+  pulse = false,
+  type = 'button',
+  children,
+  ...props
+}) => (
+  <button
+    type={type}
+    className={`rounded-2xl px-6 py-3 font-bold transition hover:-translate-y-0.5 disabled:cursor-not-allowed disabled:opacity-70 disabled:hover:translate-y-0 ${
+      VARIANTS[variant] || VARIANTS.primary
+    } ${pulse ? 'anim-pulse' : ''} ${className}`}
+    {...props}
+  >
+    {children}
+  </button>
+);
+
+export default Button;

--- a/frontend/src/components/ui/Card.jsx
+++ b/frontend/src/components/ui/Card.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+const Card = ({ as: Tag = 'div', className = '', children, ...props }) => (
+  <Tag className={`surface-card rounded-3xl ${className}`} {...props}>
+    {children}
+  </Tag>
+);
+
+export default Card;

--- a/frontend/src/components/ui/Modal.jsx
+++ b/frontend/src/components/ui/Modal.jsx
@@ -1,0 +1,28 @@
+import React, { useEffect } from 'react';
+
+const Modal = ({ open, onClose, children, closeOnBackdrop = true }) => {
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e) => {
+      if (e.key === 'Escape') onClose?.();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+      <div
+        className="absolute inset-0 bg-teal-900/30 backdrop-blur-sm dark:bg-black/50"
+        onClick={() => closeOnBackdrop && onClose?.()}
+      />
+      <div className="surface-card relative z-10 w-full max-w-sm rounded-2xl p-6">
+        {children}
+      </div>
+    </div>
+  );
+};
+
+export default Modal;

--- a/frontend/src/components/ui/Reveal.jsx
+++ b/frontend/src/components/ui/Reveal.jsx
@@ -1,0 +1,37 @@
+import React, { useEffect, useRef, useState } from 'react';
+
+const Reveal = ({ as: Tag = 'div', delay = 0, className = '', children, ...props }) => {
+  const ref = useRef(null);
+  const [shown, setShown] = useState(false);
+
+  useEffect(() => {
+    const node = ref.current;
+    if (!node) return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            setShown(true);
+            observer.unobserve(entry.target);
+          }
+        });
+      },
+      { threshold: 0.15 }
+    );
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, []);
+
+  return (
+    <Tag
+      ref={ref}
+      className={`reveal ${shown ? 'in' : ''} ${className}`}
+      style={{ animationDelay: `${delay}ms`, ...(props.style || {}) }}
+      {...props}
+    >
+      {children}
+    </Tag>
+  );
+};
+
+export default Reveal;

--- a/frontend/src/components/ui/SectionHeading.jsx
+++ b/frontend/src/components/ui/SectionHeading.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+const SectionHeading = ({ eyebrow, title, subtitle, className = '' }) => (
+  <div className={`text-center ${className}`}>
+    {eyebrow && (
+      <span className="inline-flex items-center gap-2 rounded-full bg-teal-100 px-4 py-1.5 text-sm font-semibold text-teal-700 dark:bg-ink-700 dark:text-teal-200">
+        {eyebrow}
+      </span>
+    )}
+    <h2 className="mt-4 text-3xl font-extrabold tracking-tight text-teal-900 dark:text-teal-50 sm:text-4xl">
+      {title}
+    </h2>
+    {subtitle && (
+      <p className="mx-auto mt-3 max-w-2xl text-teal-700/80 dark:text-teal-100/70">
+        {subtitle}
+      </p>
+    )}
+  </div>
+);
+
+export default SectionHeading;

--- a/frontend/src/components/ui/ThemeToggle.jsx
+++ b/frontend/src/components/ui/ThemeToggle.jsx
@@ -1,0 +1,22 @@
+import React, { useContext } from 'react';
+import { FaMoon, FaSun } from 'react-icons/fa';
+import { Context } from '../../main';
+
+const ThemeToggle = ({ className = '' }) => {
+  const { theme, setTheme } = useContext(Context);
+  const isDark = theme === 'dark';
+
+  return (
+    <button
+      type="button"
+      onClick={() => setTheme(isDark ? 'light' : 'dark')}
+      title={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
+      aria-label="Toggle color theme"
+      className={`grid h-10 w-10 place-items-center rounded-xl border-2 border-teal-200 text-teal-600 transition hover:border-teal-400 hover:text-teal-500 dark:border-ink-600 dark:text-teal-200 dark:hover:border-teal-400 ${className}`}
+    >
+      {isDark ? <FaSun size={16} /> : <FaMoon size={16} />}
+    </button>
+  );
+};
+
+export default ThemeToggle;

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,4 +1,4 @@
-import React, { createContext, useState } from 'react';
+import React, { createContext, useEffect, useState } from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App.jsx';
 
@@ -6,9 +6,40 @@ export const Context = createContext({
   isAuthenticated: false,
 });
 
+const getInitialTheme = () => {
+  try {
+    const stored = localStorage.getItem('medhaven-theme');
+    if (stored === 'light' || stored === 'dark') return stored;
+  } catch {
+    // localStorage unavailable; fall back to OS preference
+  }
+  if (
+    window.matchMedia &&
+    window.matchMedia('(prefers-color-scheme: dark)').matches
+  ) {
+    return 'dark';
+  }
+  return 'light';
+};
+
 const AppWrapper = () => {
   const [isAuthenticated, setIsAuthenticated] = useState(false);
   const [user, setUser] = useState({});
+  const [theme, setTheme] = useState(getInitialTheme);
+
+  useEffect(() => {
+    const root = document.documentElement;
+    if (theme === 'dark') {
+      root.classList.add('dark');
+    } else {
+      root.classList.remove('dark');
+    }
+    try {
+      localStorage.setItem('medhaven-theme', theme);
+    } catch {
+      // ignore persistence failures
+    }
+  }, [theme]);
 
   return (
     <Context.Provider
@@ -17,6 +48,8 @@ const AppWrapper = () => {
         setIsAuthenticated,
         user,
         setUser,
+        theme,
+        setTheme,
       }}
     >
       <App />


### PR DESCRIPTION
## Summary

A cohesive, hospital-themed redesign of the patient `frontend/` — "Calm Clinical Teal" — with polished light **and** true dark mode behind a user toggle. Scope is patient `frontend/` only; admin/doctor dashboards are untouched. Every page was restyled while preserving all existing handlers, API calls, socket events, props, refs, and routes.

- **Design system** (`App.css`, `index.html`, `main.jsx`): Tailwind v4 `@theme` tokens (teal/sand/ink palettes, Plus Jakarta Sans), class-based dark mode via `@custom-variant dark`, ambient backgrounds, shared `.field` / `.surface-card` utilities, and a `prefers-reduced-motion` guard.
- **Theme toggle + persistence**: `theme` / `setTheme` in Context, persisted to `localStorage` (`medhaven-theme`), defaulting to OS preference; `ThemeToggle` in the navbar and a floating one on `/chat` (where the navbar is hidden).
- **UI primitives** under `components/ui/`: `Button`, `Card`, `Modal`, `SectionHeading`, `Reveal`, `ThemeToggle`.
- **Pages restyled**: Navbar, Footer, Home (Hero/Biography/Departments/MessageForm), Login, Register, ForgotPassword, AppointmentForm, EditAppointment, MyAppointments (removed forced-dark wrapper), Profile (hardcoded dark → tokens), and the Chat suite (ChatList / ChatRoom bubbles / input bar / DoctorProfile / image overlays). Socket logic, refs, and upload limits are untouched.

## Test plan
- [ ] `cd frontend && npm install && npm run build` — clean (verified locally).
- [ ] Walk every route in light and dark mode, desktop + mobile widths.
- [ ] Theme toggle persists across reload; `prefers-reduced-motion` disables non-essential motion.
- [ ] Feature parity: book/edit/delete an appointment (incl. past-date disabling), login / register-with-OTP / forgot-password, profile password-change + logout + masking.
- [ ] Full chat flow with a doctor account in a second window: send/receive/edit/delete, multi-image upload (≤5MB) + overlay, department grouping, mobile back nav, realtime sockets.

> Note: `npm run lint` reports pre-existing, project-wide `react/prop-types` / unused-`React` errors that are unrelated to this revamp.